### PR TITLE
Update example payload coverage value

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -69,7 +69,7 @@ This is the payload currently expected by `codeclimate.com/test_reports`.
   "source_files": [
     {
       "blob_id": "",
-      "coverage": [null, 0, 1],
+      "coverage": "[null, 0, 1]",
       "covered_percent": 100,
       "covered_strength": 1,
       "line_counts": {


### PR DESCRIPTION
Apparently the server expects this key to contain a String value which will
parse (as JSON) to an Array. Unclear the history there, but we intend to write
the client to support the current server first, then address any interface
changes we'd like to make later.

Opening for visibility /cc @markbates