### PR TITLE
Auto-publish -head version on merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAN_FILES = $(wildcard man/*.md)
 MAN_PAGES = $(patsubst man/%.md,man/%,$(MAN_FILES))
 
 PROJECT = github.com/codeclimate/test-reporter
-VERSION = 0.1.0-rc
+VERSION ?= 0.1.0-rc
 BUILD_VERSION = $(shell git log -1 --pretty=format:'%H')
 BUILD_TIME = $(shell date +%FT%T%z)
 LDFLAGS = -ldflags "-X $(PROJECT)/cmd.Version=${VERSION} -X $(PROJECT)/cmd.BuildVersion=${BUILD_VERSION} -X $(PROJECT)/cmd.BuildTime=${BUILD_TIME}"
@@ -50,7 +50,7 @@ build-docker:
 test-ruby:
 	docker build -f examples/ruby/Dockerfile .
 
-release: build-all
+publish:
 	$(AWS) s3 sync --acl public-read artifacts/bin s3://codeclimate/test-reporter
 
 clean:

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ deployment:
     branch: master
     commands:
       - make build-all VERSION=head
-      - make release
+      - make publish
 
 notify:
   webhooks:

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,18 @@ machine:
 
 dependencies:
   override:
-    - echo "skip"
+    - pip install awscli
 
 test:
   override:
     - make test-docker
+
+deployment:
+  s3:
+    branch: master
+    commands:
+      - make build-all VERSION=head
+      - make release
 
 notify:
   webhooks:


### PR DESCRIPTION
- Allow injecting VERSION when building
- Don't depend on build-all in release
- Rename release to publish
- Build and publish a -head version on every master merge

Building and publishing versioned and -latest binaries will be handled manually,
but this will maintain a public binary that always tracks master.

I'm open to bikeshedding the `-head` bit.