### PR TITLE
Update circle ci to only publish head

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-simplecov:
 	docker build -f examples/simplecov/Dockerfile .
 
 publish:
-	$(AWS) s3 cp --acl public-read --recursive artifacts/bin/ s3://codeclimate/test-reporter/ --exclude "*" --include "test-reporter-$(VERSION)*" --include "test-reporter-latest*"
+	$(AWS) s3 cp --acl public-read --recursive artifacts/bin/ s3://codeclimate/test-reporter/ --exclude "*" --include "test-reporter-*"
 
 clean:
 	sudo $(RM) -r ./artifacts


### PR DESCRIPTION
Follow up to https://github.com/codeclimate/test-reporter/pull/86 

I didn't realize that changing `publish` was going to "break" deployment of head. Basically, more like publish is doing nothing in the case of HEAD. 