### PR TITLE
Update url to latest binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ machine:
 
 dependencies:
   post:
-    - curl -L https://tools.codeclimate.com/test-reporter/test-reporter-latest > ./cc-test-reporter
+    - curl -L https://s3.amazonaws.com/codeclimate/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     - chmod +x ./cc-test-reporter
 
 test:


### PR DESCRIPTION
We've been pointing users to try the new test reporter and the URL to get the binaries is not the right one. 
