### PR TITLE
Add coverage path as format-coverage argument

### DIFF
--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -63,13 +63,11 @@ func runFormatter(formatOptions CoverageFormatter) error {
 		if f, ok := formatterMap[formatOptions.InputType]; ok {
 			logrus.Debugf("using formatter %s", formatOptions.InputType)
 			if formatOptions.CoveragePath != "" {
-				logrus.Debug("getting coverage file")
-				p, err := f.Search(formatOptions.CoveragePath)
+				_, err := f.Search(formatOptions.CoveragePath)
 				if err != nil {
 					logrus.Errorf("could not find coverage file %s\n%s", formatOptions.CoveragePath, err)
 					return errors.WithStack(err)
 				}
-				logrus.Debugf("found file %s for %s formatter", p, f)
 			}
 			formatOptions.In = f
 		} else {

--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -20,11 +20,12 @@ import (
 )
 
 type CoverageFormatter struct {
-	In        formatters.Formatter
-	InputType string
-	Output    string
-	Prefix    string
-	writer    io.Writer
+	CoveragePath string
+	In           formatters.Formatter
+	InputType    string
+	Output       string
+	Prefix       string
+	writer       io.Writer
 }
 
 var formatOptions = CoverageFormatter{}
@@ -46,16 +47,30 @@ var formatCoverageCmd = &cobra.Command{
 	Use:   "format-coverage",
 	Short: "Locate, parse, and re-format supported coverage sources.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if args[0] != "" {
+			logrus.Debugf("coverage path %s", args[0])
+			formatOptions.CoveragePath = args[0]
+		}
 		return runFormatter(formatOptions)
 	},
 }
 
 func runFormatter(formatOptions CoverageFormatter) error {
 	envy.Set("PREFIX", formatOptions.Prefix)
+
 	// if a type is specified use that
 	if formatOptions.InputType != "" {
 		if f, ok := formatterMap[formatOptions.InputType]; ok {
 			logrus.Debugf("using formatter %s", formatOptions.InputType)
+			if formatOptions.CoveragePath != "" {
+				logrus.Debug("getting coverage file")
+				p, err := f.Search(formatOptions.CoveragePath)
+				if err != nil {
+					logrus.Errorf("could not find coverage file %s\n%s", formatOptions.CoveragePath, err)
+					return errors.WithStack(err)
+				}
+				logrus.Debugf("found file %s for %s formatter", p, f)
+			}
 			formatOptions.In = f
 		} else {
 			return errors.WithStack(errors.Errorf("could not find a formatter of type %s", formatOptions.InputType))

--- a/examples/simplecov/Dockerfile
+++ b/examples/simplecov/Dockerfile
@@ -30,6 +30,7 @@ RUN bundle exec rake; exit 0
 
 ENV CC_TEST_REPORTER_ID=c4881e09870b0fac1291c93339b36ffe36210a2645c1ad25e52d8fda3943fb4d
 
-RUN test-reporter after-build -s 5 -d
-# RUN test-reporter format-coverage -d
-# RUN test-reporter upload-coverage -d -s 5
+# RUN test-reporter after-build -s 5 -d
+
+RUN test-reporter format-coverage -d -t simplecov $PWD/coverage/.resultset.json
+RUN test-reporter upload-coverage -d -s 5

--- a/examples/simplecov/Dockerfile
+++ b/examples/simplecov/Dockerfile
@@ -30,7 +30,9 @@ RUN bundle exec rake; exit 0
 
 ENV CC_TEST_REPORTER_ID=c4881e09870b0fac1291c93339b36ffe36210a2645c1ad25e52d8fda3943fb4d
 
-# RUN test-reporter after-build -s 5 -d
+RUN test-reporter after-build -s 5 -d
 
-RUN test-reporter format-coverage -d -t simplecov $PWD/coverage/.resultset.json
-RUN test-reporter upload-coverage -d -s 5
+# test coverage on a non-default path
+# RUN mv coverage custom-coverage
+# RUN test-reporter format-coverage -d -t simplecov custom-coverage/.resultset.json
+# RUN test-reporter upload-coverage -d -s 5

--- a/formatters/simplecov/simplecov.go
+++ b/formatters/simplecov/simplecov.go
@@ -42,6 +42,7 @@ func (f *Formatter) Parse() error {
 	}
 	jf, err := os.Open(f.Path)
 	if err != nil {
+		logrus.Debugf("failed to open coverage file %s", f.Path)
 		return errors.WithStack(err)
 	}
 	m := map[string]input{}

--- a/formatters/simplecov/simplecov.go
+++ b/formatters/simplecov/simplecov.go
@@ -42,7 +42,6 @@ func (f *Formatter) Parse() error {
 	}
 	jf, err := os.Open(f.Path)
 	if err != nil {
-		logrus.Debugf("failed to open coverage file %s", f.Path)
 		return errors.WithStack(err)
 	}
 	m := map[string]input{}

--- a/man/cc-test-reporter-format-coverage.1.md
+++ b/man/cc-test-reporter-format-coverage.1.md
@@ -8,13 +8,17 @@ This is a sub-command of **cc-test-reporter**(1).
 
 # SYNOPSIS
 
-**cc-test-reporter-format-coverage** [--output=\<path>] [--prefix=\<path>]
+**cc-test-reporter-format-coverage** [--input-type=\<coverage type>] [--output=\<path>] [--prefix=\<path>] [COVERAGE_FILE]
 
 # DESCRIPTION
 
 Locate, parse, and re-format supported coverage sources.
 
 # OPTIONS
+
+## -t, --input-type *COVERAGE TYPE*
+
+Tool used to generate the coverage data.
 
 ## -o, --output *PATH*
 
@@ -26,6 +30,11 @@ to *coverage/codeclimate.json*.
 The prefix to remove from absolute paths in coverage payloads, to make
 them relative to the project root. This is usually the directory in which the
 tests were run. Defaults to current working directory.
+
+## COVERAGE_FILE
+
+Path where the coverage file is located. It requires the flag `--input-type`
+to be set.
 
 # SUPPORTED SOURCES
 


### PR DESCRIPTION
for the command to take into account the path, it must be run as:
```
test-reporter format-coverage -t simplecov <coverage_path>
```