### PR TITLE
	Publish head from Circle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ test-gocov:
 test-clover:
 	docker build -f examples/clover/Dockerfile .
 
+publish-head:
+	$(AWS) s3 cp \
+	  --acl public-read \
+	  artifacts/bin/test-reporter-head-* s3://codeclimate/test-reporter/
+
 publish-latest:
 	$(AWS) s3 cp \
 	  --acl public-read \

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ deployment:
     branch: master
     commands:
       - make build-all VERSION=head
-      - make publish
+      - make publish-head
 
 notify:
   webhooks:


### PR DESCRIPTION
We will publish latest and the version manually, but `head` will be
automatic