### PR TITLE
Revert stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## Unreleased
 
-## v1.0.1 [(2017-05-18)](https://github.com/codeclimate/test-reporter/releases/tag/v1.0.1)
+## v0.1.6 [(2017-05-18)](https://github.com/codeclimate/test-reporter/releases/tag/v0.1.6)
 
 * [FIX] `format-coverage` when COVERAGE_FILE arg is not present
-
-## v1.0.0 [(2017-05-18)](https://github.com/codeclimate/test-reporter/releases/tag/v1.0.0)
-
-* [NEW] Stable release!
 
 ## v0.1.5 [(2017-05-17)](https://github.com/codeclimate/test-reporter/releases/tag/v0.1.5)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAN_FILES = $(wildcard man/*.md)
 MAN_PAGES = $(patsubst man/%.md,man/%,$(MAN_FILES))
 
 PROJECT = github.com/codeclimate/test-reporter
-VERSION ?= 1.0.1
+VERSION ?= 0.1.6
 BUILD_VERSION = $(shell git log -1 --pretty=format:'%H')
 BUILD_TIME = $(shell date +%FT%T%z)
 LDFLAGS = -ldflags "-X $(PROJECT)/version.Version=${VERSION} -X $(PROJECT)/version.BuildVersion=${BUILD_VERSION} -X $(PROJECT)/version.BuildTime=${BUILD_TIME}"


### PR DESCRIPTION
We're holding off on a stable release for now.

Release v0.1.6 with previous v1.0.1 updates