### PR TITLE
Optimize sum-coverage

### DIFF
--- a/cmd/sum-coverage.go
+++ b/cmd/sum-coverage.go
@@ -46,9 +46,9 @@ var sumCoverageCmd = &cobra.Command{
 				return errors.WithStack(err)
 			}
 			err = rep.Merge(&rr)
-      if err != nil {
+			if err != nil {
 				return errors.WithStack(err)
-      }
+			}
 		}
 
 		err = os.MkdirAll(filepath.Dir(summerOptions.Output), 0755)

--- a/cmd/sum-coverage.go
+++ b/cmd/sum-coverage.go
@@ -45,7 +45,10 @@ var sumCoverageCmd = &cobra.Command{
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			rep.Merge(&rr)
+			err = rep.Merge(&rr)
+      if err != nil {
+				return errors.WithStack(err)
+      }
 		}
 
 		err = os.MkdirAll(filepath.Dir(summerOptions.Output), 0755)

--- a/formatters/report.go
+++ b/formatters/report.go
@@ -121,32 +121,32 @@ func (a *Report) Merge(reps ...*Report) error {
 func (rep *Report) AddSourceFile(sf SourceFile) error {
 	var err error
 
-  // check if we already know about this file
+	// check if we already know about this file
 	if s, ok := rep.SourceFiles[sf.Name]; ok {
-    // remove the old values... we know more now
-    rep.LineCounts.Covered -= s.LineCounts.Covered
-    rep.LineCounts.Missed -= s.LineCounts.Missed
-    rep.LineCounts.Total -= s.LineCounts.Total
+		// remove the old values... we know more now
+		rep.LineCounts.Covered -= s.LineCounts.Covered
+		rep.LineCounts.Missed -= s.LineCounts.Missed
+		rep.LineCounts.Total -= s.LineCounts.Total
 
 		sf, err = s.Merge(sf)
 		if err != nil {
 			return err
 		}
 
-    // pop the source file in
-    rep.SourceFiles[sf.Name] = sf
+		// pop the source file in
+		rep.SourceFiles[sf.Name] = sf
 
-    // add the new, more correct numbers
-    rep.LineCounts.Covered += sf.LineCounts.Covered
-    rep.LineCounts.Missed += sf.LineCounts.Missed
-    rep.LineCounts.Total += sf.LineCounts.Total
+		// add the new, more correct numbers
+		rep.LineCounts.Covered += sf.LineCounts.Covered
+		rep.LineCounts.Missed += sf.LineCounts.Missed
+		rep.LineCounts.Total += sf.LineCounts.Total
 	} else {
-	  sf.CalcLineCounts()
-    rep.SourceFiles[sf.Name] = sf
-    rep.LineCounts.Covered += sf.LineCounts.Covered
-    rep.LineCounts.Missed += sf.LineCounts.Missed
-    rep.LineCounts.Total += sf.LineCounts.Total
-  }
+		sf.CalcLineCounts()
+		rep.SourceFiles[sf.Name] = sf
+		rep.LineCounts.Covered += sf.LineCounts.Covered
+		rep.LineCounts.Missed += sf.LineCounts.Missed
+		rep.LineCounts.Total += sf.LineCounts.Total
+	}
 
 	rep.CoveredPercent = rep.LineCounts.CoveredPercent()
 	return nil

--- a/formatters/report.go
+++ b/formatters/report.go
@@ -120,22 +120,34 @@ func (a *Report) Merge(reps ...*Report) error {
 
 func (rep *Report) AddSourceFile(sf SourceFile) error {
 	var err error
+
+  // check if we already know about this file
 	if s, ok := rep.SourceFiles[sf.Name]; ok {
+    // remove the old values... we know more now
+    rep.LineCounts.Covered -= s.LineCounts.Covered
+    rep.LineCounts.Missed -= s.LineCounts.Missed
+    rep.LineCounts.Total -= s.LineCounts.Total
+
 		sf, err = s.Merge(sf)
 		if err != nil {
 			return err
 		}
-	}
-	sf.CalcLineCounts()
-	rep.SourceFiles[sf.Name] = sf
 
-	lc := LineCounts{}
-	for _, s := range rep.SourceFiles {
-		lc.Covered += s.LineCounts.Covered
-		lc.Missed += s.LineCounts.Missed
-		lc.Total += s.LineCounts.Total
-	}
-	rep.LineCounts = lc
+    // pop the source file in
+    rep.SourceFiles[sf.Name] = sf
+
+    // add the new, more correct numbers
+    rep.LineCounts.Covered += sf.LineCounts.Covered
+    rep.LineCounts.Missed += sf.LineCounts.Missed
+    rep.LineCounts.Total += sf.LineCounts.Total
+	} else {
+	  sf.CalcLineCounts()
+    rep.SourceFiles[sf.Name] = sf
+    rep.LineCounts.Covered += sf.LineCounts.Covered
+    rep.LineCounts.Missed += sf.LineCounts.Missed
+    rep.LineCounts.Total += sf.LineCounts.Total
+  }
+
 	rep.CoveredPercent = rep.LineCounts.CoveredPercent()
 	return nil
 }

--- a/formatters/report_test.go
+++ b/formatters/report_test.go
@@ -118,34 +118,33 @@ func Test_Merge_Issue_103(t *testing.T) {
 	a, err := NewReport()
 	r.NoError(err)
 
-	a.SourceFiles = SourceFiles{
-		"app/jobs/initialize_account_seats.rb": SourceFile{
-			Name:           "app/jobs/initialize_account_seats.rb",
-			CoveredPercent: 100,
-			Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(15), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}},
-			LineCounts: LineCounts{
-				Missed:  0,
-				Covered: 8,
-				Total:   8,
-			},
-		},
-	}
+  sf := SourceFile{
+    Name:           "app/jobs/initialize_account_seats.rb",
+    CoveredPercent: 100,
+    Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(15), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}},
+    LineCounts: LineCounts{
+      Missed:  0,
+      Covered: 8,
+      Total:   8,
+    },
+  }
+  a.AddSourceFile(sf)
 
 	b, err := NewReport()
 	r.NoError(err)
 
-	b.SourceFiles = SourceFiles{
-		"app/jobs/initialize_account_seats.rb": SourceFile{
-			Name:           "app/jobs/initialize_account_seats.rb",
-			CoveredPercent: 62.5,
-			Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}},
-			LineCounts: LineCounts{
-				Missed:  3,
-				Covered: 5,
-				Total:   8,
-			},
-		},
-	}
+  sf2 := SourceFile{
+    Name:           "app/jobs/initialize_account_seats.rb",
+    CoveredPercent: 62.5,
+    Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}},
+    LineCounts: LineCounts{
+      Missed:  3,
+      Covered: 5,
+      Total:   8,
+    },
+  }
+
+  b.AddSourceFile(sf2)
 
 	err = a.Merge(&b)
 	r.NoError(err)

--- a/formatters/report_test.go
+++ b/formatters/report_test.go
@@ -118,33 +118,33 @@ func Test_Merge_Issue_103(t *testing.T) {
 	a, err := NewReport()
 	r.NoError(err)
 
-  sf := SourceFile{
-    Name:           "app/jobs/initialize_account_seats.rb",
-    CoveredPercent: 100,
-    Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(15), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}},
-    LineCounts: LineCounts{
-      Missed:  0,
-      Covered: 8,
-      Total:   8,
-    },
-  }
-  a.AddSourceFile(sf)
+	sf := SourceFile{
+		Name:           "app/jobs/initialize_account_seats.rb",
+		CoveredPercent: 100,
+		Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(15), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(3), nulls.Int{}, nulls.Int{}},
+		LineCounts: LineCounts{
+			Missed:  0,
+			Covered: 8,
+			Total:   8,
+		},
+	}
+	a.AddSourceFile(sf)
 
 	b, err := NewReport()
 	r.NoError(err)
 
-  sf2 := SourceFile{
-    Name:           "app/jobs/initialize_account_seats.rb",
-    CoveredPercent: 62.5,
-    Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}},
-    LineCounts: LineCounts{
-      Missed:  3,
-      Covered: 5,
-      Total:   8,
-    },
-  }
+	sf2 := SourceFile{
+		Name:           "app/jobs/initialize_account_seats.rb",
+		CoveredPercent: 62.5,
+		Coverage:       Coverage{nulls.NewInt(1), nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}, nulls.NewInt(1), nulls.Int{}, nulls.NewInt(1), nulls.NewInt(0), nulls.Int{}, nulls.Int{}},
+		LineCounts: LineCounts{
+			Missed:  3,
+			Covered: 5,
+			Total:   8,
+		},
+	}
 
-  b.AddSourceFile(sf2)
+	b.AddSourceFile(sf2)
 
 	err = a.Merge(&b)
 	r.NoError(err)


### PR DESCRIPTION
We'd like to avoid looping through a report's source files each time we add a new source file.

The reason I needed to change the test is because this implementation only works if only only add source files via the `AddSourceFile` method... (which is the case in the sum-coverage command code)

For a large data set, this shaves the sum-coverage time from 24m to 4m (on my laptop).

Also, this may be a "drive by", but I added some error-handling code in the call to `report.Merge`; I was hitting this in my initial benchmarking, and thought it was succeeding quickly in some cases, but it was actually failing quickly. We're planning to remove this command's dependence on git, so maybe I should just remove that commit?