### PR TITLE
Minimize talking to git during sum-coverage

### DIFF
--- a/cmd/sum-coverage.go
+++ b/cmd/sum-coverage.go
@@ -32,14 +32,14 @@ var sumCoverageCmd = &cobra.Command{
 		if err != nil {
 			return errors.WithStack(err)
 		}
+
 		for _, n := range args {
 			f, err := os.Open(n)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			rr, err := formatters.NewReport()
-			if err != nil {
-				return errors.WithStack(err)
+			rr := formatters.Report{
+				SourceFiles: formatters.SourceFiles{},
 			}
 			err = json.NewDecoder(f).Decode(&rr)
 			if err != nil {

--- a/formatters/report.go
+++ b/formatters/report.go
@@ -3,6 +3,7 @@ package formatters
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -105,8 +106,8 @@ func NewReport() (Report, error) {
 
 func (a *Report) Merge(reps ...*Report) error {
 	for _, r := range reps {
-		if a.Git.Head != r.Git.Head {
-			return errors.New("git heads do not match")
+		if a.Git.Head != "" && a.Git.Head != r.Git.Head {
+			return errors.New(fmt.Sprintf("git heads do not match: %v, %v", a.Git.Head, r.Git.Head))
 		}
 		for _, sf := range r.SourceFiles {
 			err := a.AddSourceFile(sf)

--- a/formatters/report_test.go
+++ b/formatters/report_test.go
@@ -24,7 +24,7 @@ func Test_Report_Merge_Bad_GitHead(t *testing.T) {
 	}
 	err := a.Merge(b)
 	r.Error(err)
-	r.Equal("git heads do not match", err.Error())
+	r.Equal("git heads do not match: a, b", err.Error())
 }
 
 func Test_Report_Merge_MismatchedCoverageLength(t *testing.T) {


### PR DESCRIPTION
With this change, I'm down to 204 seconds locally.

We still talk to git once, when estting up the initial report that we
then merge all the actual reports into. If we don't, we don't get the
git or ci_service attributes filled in

(note: opening this against the earlier branch with the already-approved PR. Not sure how to go about releasing changes here...)