### PR TITLE
Avoid going to Git or env in sum-coverage

### DIFF
--- a/cmd/sum-coverage.go
+++ b/cmd/sum-coverage.go
@@ -28,19 +28,30 @@ var sumCoverageCmd = &cobra.Command{
 			return errors.Errorf("expected %d parts, received only %d parts", summerOptions.Parts, len(args))
 		}
 
-		rep, err := formatters.NewReport()
+		rep := formatters.Report{
+			SourceFiles: formatters.SourceFiles{},
+		}
+
+		f, err := os.Open(args[0])
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		for _, n := range args {
+
+		err = json.NewDecoder(f).Decode(&rep)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		for _, n := range args[1:] {
 			f, err := os.Open(n)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			rr, err := formatters.NewReport()
-			if err != nil {
-				return errors.WithStack(err)
+
+			rr := formatters.Report{
+				SourceFiles: formatters.SourceFiles{},
 			}
+
 			err = json.NewDecoder(f).Decode(&rr)
 			if err != nil {
 				return errors.WithStack(err)


### PR DESCRIPTION
We already have all the information we need in the reports that we're
aggregating.

The approach is to take the first report's info, then merge subsequent
reports into that one.

Hat tip to Ale for the direction.

(This gets the performance from 240s to 205s in my local benchmark)

(Just re-ran the ruby one, and it took 214s -- so we're officially "beating" it)

Related to https://github.com/codeclimate/test-reporter/issues/157