### PR TITLE
sum-coverage nulls take precendence over numbers

### DIFF
--- a/formatters/simplecov/format_test.go
+++ b/formatters/simplecov/format_test.go
@@ -58,14 +58,14 @@ func Test_Format_Merged(t *testing.T) {
 	rep, err := rb.Format()
 	r.NoError(err)
 
-	r.InDelta(100, rep.CoveredPercent, 1)
+	r.InDelta(75.0, rep.CoveredPercent, 1)
 	r.Len(rep.SourceFiles, 1)
 
 	sf := rb.Tests[0].SourceFiles[0]
-	r.InDelta(100, sf.CoveredPercent, 1)
+	r.InDelta(33.3, sf.CoveredPercent, 1)
 
 	lc := rep.LineCounts
-	r.Equal(lc.Covered, 10)
-	r.Equal(lc.Missed, 0)
-	r.Equal(lc.Total, 10)
+	r.Equal(lc.Covered, 6)
+	r.Equal(lc.Missed, 2)
+	r.Equal(lc.Total, 8)
 }

--- a/formatters/simplecov/simplecov-merged.json
+++ b/formatters/simplecov/simplecov-merged.json
@@ -5,12 +5,12 @@
         1,
         1,
         1,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
         null
       ]
     },
@@ -19,16 +19,16 @@
   "name-b": {
     "coverage": {
       "/home/patrick/code/codeclimate/ruby-test-reporter/lib/codeclimate-test-reporter.rb": [
+        0,
+        0,
+        0,
+        0,
+        0,
         null,
-        null,
-        null,
         1,
         1,
         1,
-        1,
-        1,
-        1,
-        1
+        0
       ]
     },
     "timestamp": 1489777982

--- a/formatters/source_file.go
+++ b/formatters/source_file.go
@@ -37,13 +37,13 @@ func (a SourceFile) Merge(b SourceFile) (SourceFile, error) {
 			continue
 		}
 
-		if !bc.Valid {
-			//default is to nothing and use the ac value
+		// ac is null and bc isn't so ac takes precendence, we do nothing
+		if !ac.Valid {
 			continue
 		}
 
-		// ac is null and bc isn't so use bc
-		if !ac.Valid {
+		// bc is null and ac isn't so bc takes precendence
+		if !bc.Valid {
 			a.Coverage[i] = bc
 		}
 

--- a/formatters/source_file_test.go
+++ b/formatters/source_file_test.go
@@ -7,7 +7,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_SourceFile_Merge(t *testing.T) {
+func Test_SourceFile_Merge_With_Numbers(t *testing.T) {
+	r := require.New(t)
+	a := SourceFile{
+		BlobID:   "a",
+		Coverage: Coverage{nulls.NewInt(0), nulls.NewInt(2), nulls.NewInt(3), nulls.NewInt(0)},
+	}
+	b := SourceFile{
+		BlobID:   "b",
+		Coverage: Coverage{nulls.NewInt(1), nulls.NewInt(0), nulls.NewInt(1), nulls.NewInt(0)},
+	}
+
+	c, err := a.Merge(b)
+	r.NoError(err)
+	r.Equal("a", c.BlobID)
+	r.Equal(4, len(c.Coverage))
+	r.Equal(Coverage{nulls.NewInt(1), nulls.NewInt(2), nulls.NewInt(4), nulls.NewInt(0)}, c.Coverage)
+	r.InDelta(75.0, c.CoveredPercent, 1)
+	r.InDelta(2.2, c.CoveredStrength, 1)
+	r.Equal(LineCounts{Total: 4, Missed: 1, Covered: 3, Strength: 7}, c.LineCounts)
+}
+
+func Test_SourceFile_Merge_With_Nulls(t *testing.T) {
 	r := require.New(t)
 	a := SourceFile{
 		BlobID:   "a",
@@ -15,16 +36,17 @@ func Test_SourceFile_Merge(t *testing.T) {
 	}
 	b := SourceFile{
 		BlobID:   "b",
-		Coverage: Coverage{nulls.NewInt(1), nulls.Int{}, nulls.NewInt(3), nulls.Int{}},
+		Coverage: Coverage{nulls.NewInt(1), nulls.Int{}, nulls.NewInt(3), nulls.NewInt(3)},
 	}
 
 	c, err := a.Merge(b)
 	r.NoError(err)
 	r.Equal("a", c.BlobID)
 	r.Equal(4, len(c.Coverage))
-	r.InDelta(75.0, c.CoveredPercent, 1)
-	r.InDelta(2.2, c.CoveredStrength, 1)
-	r.Equal(LineCounts{Total: 4, Missed: 1, Covered: 3, Strength: 9}, c.LineCounts)
+	r.Equal(Coverage{nulls.Int{}, nulls.Int{}, nulls.NewInt(6), nulls.NewInt(3)}, c.Coverage)
+	r.InDelta(100.0, c.CoveredPercent, 1)
+	r.InDelta(4.5, c.CoveredStrength, 1)
+	r.Equal(LineCounts{Total: 2, Missed: 0, Covered: 2, Strength: 9}, c.LineCounts)
 }
 
 func Test_SourceFile_BlobID(t *testing.T) {


### PR DESCRIPTION
When a summing source file coverages:
```
[1, 0, null] + [2, 1, 0] = [3, 1, null]
```
This intends to support correct sum behavior for those
users using Simplecov's track_files

Related to https://github.com/codeclimate/test-reporter/issues/158