### PR TITLE
Ensure using fallback blob_id method when git fails

### DIFF
--- a/env/git.go
+++ b/env/git.go
@@ -112,25 +112,20 @@ func GitSHA(path string) (string, error) {
 }
 
 var GitBlob = func(path string, commit *object.Commit) (string, error) {
-	if commit == nil {
-		blob, err := fallbackBlob(path)
+	if commit != nil {
+		if file, err := commit.File(path); err == nil {
+			logrus.Debugf("getting git blob_id for source file %s", path)
 
-		if err != nil {
-			return "", errors.WithStack(err)
+			blob := strings.TrimSpace(file.Hash.String())
+			return blob, nil
 		}
-
-		return blob, nil
 	}
 
-	logrus.Debugf("getting git blob_id for source file %s", path)
-	file, err := commit.File(path)
+	blob, err := fallbackBlob(path)
 
 	if err != nil {
-		logrus.Errorf("failed to find file %s\n%s", path, err)
 		return "", errors.WithStack(err)
 	}
-
-	blob := strings.TrimSpace(file.Hash.String())
 
 	return blob, nil
 }
@@ -146,6 +141,7 @@ func fallbackBlob(path string) (string, error) {
 
 	hash := plumbing.ComputeHash(plumbing.BlobObject, []byte(file))
 	res := hash.String()
+
 	return res, nil
 }
 

--- a/env/git.go
+++ b/env/git.go
@@ -113,7 +113,8 @@ func GitSHA(path string) (string, error) {
 
 var GitBlob = func(path string, commit *object.Commit) (string, error) {
 	if commit != nil {
-		if file, err := commit.File(path); err == nil {
+		file, err := commit.File(path)
+		if err == nil {
 			logrus.Debugf("getting git blob_id for source file %s", path)
 
 			blob := strings.TrimSpace(file.Hash.String())


### PR DESCRIPTION
We were only using the fallback method if we fail to find HEAD,
but this leads to unexpected behavior. An user can be on a valid
git state and still get an error when getting the blob id if the
file is being .gitignore.

This change will try to get the blob id by reading the file if getting
it from git fails because git is not available or if the file is not found on the commit.