### PR TITLE
Ensure we search for coverage file before formmating

### DIFF
--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -68,12 +68,10 @@ func runFormatter(formatOptions CoverageFormatter) error {
 	if formatOptions.InputType != "" {
 		if f, ok := formatterMap[formatOptions.InputType]; ok {
 			logrus.Debugf("using formatter %s", formatOptions.InputType)
-			if formatOptions.CoveragePath != "" {
-				_, err := f.Search(formatOptions.CoveragePath)
-				if err != nil {
-					logrus.Errorf("could not find coverage file %s\n%s", formatOptions.CoveragePath, err)
-					return errors.WithStack(err)
-				}
+			_, err := f.Search(formatOptions.CoveragePath)
+			if err != nil {
+				logrus.Errorf("could not find coverage file %s\n%s", formatOptions.CoveragePath, err)
+				return errors.WithStack(err)
 			}
 			formatOptions.In = f
 		} else {

--- a/formatters/simplecov/simplecov.go
+++ b/formatters/simplecov/simplecov.go
@@ -38,7 +38,7 @@ func (r Formatter) Format() (formatters.Report, error) {
 
 	jf, err := os.Open(r.Path)
 	if err != nil {
-		return rep, errors.WithStack(err)
+		return rep, errors.WithStack(errors.Errorf("could not open coverage file %s", r.Path))
 	}
 
 	m := map[string]input{}


### PR DESCRIPTION
We should call search even if user doesn't pass a coverage path. In this case, `Search` will infer the location. 

Addresses this issue https://github.com/codeclimate/test-reporter/issues/184