### PR TITLE
Fix Cobertura coverage array

### DIFF
--- a/formatters/cobertura/cobertura.go
+++ b/formatters/cobertura/cobertura.go
@@ -3,6 +3,7 @@ package cobertura
 import (
 	"encoding/xml"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -55,6 +56,7 @@ func (r Formatter) Format() (formatters.Report, error) {
 			if err != nil {
 				return rep, errors.WithStack(err)
 			}
+			sort.Sort(ByLineNum(pf.Lines))
 			for _, l := range pf.Lines {
 				for num < l.Num {
 					sf.Coverage = append(sf.Coverage, formatters.NullInt{})

--- a/formatters/cobertura/cobertura.go
+++ b/formatters/cobertura/cobertura.go
@@ -62,9 +62,14 @@ func (r Formatter) Format() (formatters.Report, error) {
 					sf.Coverage = append(sf.Coverage, formatters.NullInt{})
 					num++
 				}
-				ni := formatters.NewNullInt(l.Hits)
-				sf.Coverage = append(sf.Coverage, ni)
-				num++
+				if l.Num <= len(sf.Coverage) {
+					hits := sf.Coverage[l.Num-1].Int + l.Hits
+					sf.Coverage[l.Num-1] = formatters.NewNullInt(hits)
+				} else {
+					ni := formatters.NewNullInt(l.Hits)
+					sf.Coverage = append(sf.Coverage, ni)
+					num++
+				}
 			}
 			sf.CalcLineCounts()
 			err = rep.AddSourceFile(sf)

--- a/formatters/cobertura/cobertura_test.go
+++ b/formatters/cobertura/cobertura_test.go
@@ -30,4 +30,6 @@ func Test_Parse(t *testing.T) {
 	r.True(sf.Coverage[11].Valid)
 	r.Equal(0, sf.Coverage[10].Int)
 	r.Equal(3, sf.Coverage[11].Int)
+	r.Equal(21, sf.Coverage[19].Int)
+	r.Equal(15, sf.Coverage[20].Int)
 }

--- a/formatters/cobertura/example.xml
+++ b/formatters/cobertura/example.xml
@@ -88,6 +88,7 @@
             </method>
           </methods>
           <lines>
+            <line number="29" hits="9" branch="false" />
             <line number="12" hits="3" branch="false" />
             <line number="16" hits="3" branch="false" />
             <line number="18" hits="12" branch="true" condition-coverage="100% (2/2)">
@@ -167,7 +168,6 @@
               </conditions>
             </line>
             <line number="19" hits="0" branch="false" />
-            <line number="24" hits="0" branch="false" />
           </lines>
         </class>
       </classes>

--- a/formatters/cobertura/example.xml
+++ b/formatters/cobertura/example.xml
@@ -104,6 +104,7 @@
               </conditions>
             </line>
             <line number="24" hits="0" branch="false" />
+            <line number="21" hits="6" branch="false" />
             <line number="25" hits="9" branch="true" condition-coverage="100% (2/2)">
               <conditions>
                 <condition number="0" type="jump" coverage="100%" />
@@ -111,8 +112,9 @@
             </line>
             <line number="26" hits="6" branch="false" />
             <line number="28" hits="3" branch="false" />
-            <line number="29" hits="9" branch="false" />
+            <line number="20" hits="5" branch="false" />
             <line number="31" hits="3" branch="false" />
+            <line number="20" hits="7" branch="false" />
           </lines>
         </class>
         <class name="search.ISortedArraySearch" filename="search/ISortedArraySearch.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
@@ -168,6 +170,7 @@
               </conditions>
             </line>
             <line number="19" hits="0" branch="false" />
+            <line number="24" hits="0" branch="false" />
           </lines>
         </class>
       </classes>

--- a/formatters/cobertura/xml.go
+++ b/formatters/cobertura/xml.go
@@ -2,17 +2,26 @@ package cobertura
 
 import "encoding/xml"
 
+type Lines struct {
+	Num  int `xml:"number,attr"`
+	Hits int `xml:"hits,attr"`
+}
+
 type xmlFile struct {
 	XMLName  xml.Name `xml:"coverage"`
 	Packages []struct {
 		Name    string `xml:"name,attr"`
 		Classes []struct {
-			Name     string `xml:"name,attr"`
-			FileName string `xml:"filename,attr"`
-			Lines    []struct {
-				Num  int `xml:"number,attr"`
-				Hits int `xml:"hits,attr"`
-			} `xml:"lines>line"`
+			Name     string  `xml:"name,attr"`
+			FileName string  `xml:"filename,attr"`
+			Lines    []Lines `xml:"lines>line"`
 		} `xml:"classes>class"`
 	} `xml:"packages>package"`
 }
+
+// Interface to sort []Lines by line number
+type ByLineNum []Lines
+
+func (a ByLineNum) Len() int           { return len(a) }
+func (a ByLineNum) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByLineNum) Less(i, j int) bool { return a[i].Num < a[j].Num }


### PR DESCRIPTION
Cobertura formatter is currently working under the assumption that the coverage tool is gonna report lines ordered by number and without duplicate line numbers. This causes that for coverage data that looks like this:
```xml
<package name="" line-rate="1.0" branch-rate="1.0" complexity="1.0">
  <classes>
    <class name="Main" filename="Main.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
      <lines>
        <line number="4" hits="8" branch="false" />
        <line number="2" hits="4" branch="false" />
        <line number="4" hits="1" branch="false" />
        <line number="1" hits="6" branch="false" />
      </lines>
    </class>
  </classes>
</package>
```
We're going to incorrectly report a coverage array of `[0, 0, 0, 8, 4,1,6]`. And we should report `[6, 4, nil,9]`

This PR addresses this issues by: 

* Sorting lines by number before building the coverage array
* For lines with the same number, we're going to sum the hits

