### PR TITLE
Format properly inner classes in Cobertura

### DIFF
--- a/formatters/cobertura/cobertura_test.go
+++ b/formatters/cobertura/cobertura_test.go
@@ -32,4 +32,9 @@ func Test_Parse(t *testing.T) {
 	r.Equal(3, sf.Coverage[11].Int)
 	r.Equal(21, sf.Coverage[19].Int)
 	r.Equal(15, sf.Coverage[20].Int)
+
+	sf = rep.SourceFiles["search/LinearSearch.java"]
+	r.Equal(2, sf.Coverage[9].Int)
+	r.Equal(3, sf.Coverage[23].Int)
+	r.Equal(5, sf.Coverage[39].Int)
 }

--- a/formatters/cobertura/example.xml
+++ b/formatters/cobertura/example.xml
@@ -173,6 +173,20 @@
             <line number="24" hits="0" branch="false" />
           </lines>
         </class>
+        <class name="search.LinearSearch$1" filename="search/LinearSearch.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+          <methods>
+            <method name="&lt;init&gt;" signature="()V" line-rate="1.0" branch-rate="1.0">
+              <lines>
+                <line number="9" hits="3" branch="false" />
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="10" hits="2" branch="false" />
+            <line number="24" hits="3" branch="false" />
+            <line number="40" hits="5" branch="false" />
+          </lines>
+        </class>
       </classes>
     </package>
   </packages>

--- a/formatters/cobertura/xml.go
+++ b/formatters/cobertura/xml.go
@@ -7,15 +7,17 @@ type Lines struct {
 	Hits int `xml:"hits,attr"`
 }
 
+type xmlClass struct {
+	Name     string  `xml:"name,attr"`
+	FileName string  `xml:"filename,attr"`
+	Lines    []Lines `xml:"lines>line"`
+}
+
 type xmlFile struct {
 	XMLName  xml.Name `xml:"coverage"`
 	Packages []struct {
-		Name    string `xml:"name,attr"`
-		Classes []struct {
-			Name     string  `xml:"name,attr"`
-			FileName string  `xml:"filename,attr"`
-			Lines    []Lines `xml:"lines>line"`
-		} `xml:"classes>class"`
+		Name    string     `xml:"name,attr"`
+		Classes []xmlClass `xml:"classes>class"`
 	} `xml:"packages>package"`
 }
 


### PR DESCRIPTION
* Cobertura represents inner classes as another class with the same file on the XML file. `test-reporter` failed to format coverage on those cases. 
* Update specs to test inner class 

Addresses https://github.com/codeclimate/test-reporter/issues/204 