### PR TITLE
Fix clover formatter

### DIFF
--- a/formatters/clover/clover.go
+++ b/formatters/clover/clover.go
@@ -41,33 +41,37 @@ func (r Formatter) Format() (formatters.Report, error) {
 		return rep, errors.WithStack(err)
 	}
 
-	c := &xmlFile{}
+	c := &xmlClover{}
 	err = xml.NewDecoder(fx).Decode(c)
 	if err != nil {
 		return rep, errors.WithStack(err)
 	}
 
 	gitHead, _ := env.GetHead()
+
+	files := c.Files
 	for _, pp := range c.Packages {
-		for _, pf := range pp.Files {
-			num := 1
-			sf, err := formatters.NewSourceFile(pf.Name, gitHead)
-			if err != nil {
-				return rep, errors.WithStack(err)
-			}
-			for _, l := range pf.Lines {
-				for num < l.Num {
-					sf.Coverage = append(sf.Coverage, formatters.NullInt{})
-					num++
-				}
-				ni := formatters.NewNullInt(l.Count)
-				sf.Coverage = append(sf.Coverage, ni)
+		files = append(files, pp.Files...)
+	}
+
+	for _, pf := range files {
+		num := 1
+		sf, err := formatters.NewSourceFile(pf.Name, gitHead)
+		if err != nil {
+			return rep, errors.WithStack(err)
+		}
+		for _, l := range pf.Lines {
+			for num < l.Num {
+				sf.Coverage = append(sf.Coverage, formatters.NullInt{})
 				num++
 			}
-			err = rep.AddSourceFile(sf)
-			if err != nil {
-				return rep, errors.WithStack(err)
-			}
+			ni := formatters.NewNullInt(l.Count)
+			sf.Coverage = append(sf.Coverage, ni)
+			num++
+		}
+		err = rep.AddSourceFile(sf)
+		if err != nil {
+			return rep, errors.WithStack(err)
 		}
 	}
 

--- a/formatters/clover/clover_test.go
+++ b/formatters/clover/clover_test.go
@@ -21,7 +21,7 @@ func Test_Parse(t *testing.T) {
 	f := &Formatter{Path: "./example.xml"}
 	rep, err := f.Format()
 	r.NoError(err)
-	r.Len(rep.SourceFiles, 12)
+	r.Len(rep.SourceFiles, 13)
 
 	sf := rep.SourceFiles["/Users/markbates/Dropbox/development/php-test-reporter/src/TestReporter/Entity/CiInfo.php"]
 	r.InDelta(91.78, sf.CoveredPercent, 1)
@@ -30,4 +30,27 @@ func Test_Parse(t *testing.T) {
 	r.True(sf.Coverage[54].Valid)
 	r.Equal(4, sf.Coverage[53].Int)
 	r.Equal(0, sf.Coverage[55].Int)
+}
+
+func Test_Parse_Without_Package(t *testing.T) {
+	gb := env.GitBlob
+	defer func() { env.GitBlob = gb }()
+	env.GitBlob = func(s string, c *object.Commit) (string, error) {
+		return s, nil
+	}
+
+	r := require.New(t)
+
+	f := &Formatter{Path: "./example_without_package.xml"}
+	rep, err := f.Format()
+	r.NoError(err)
+	r.Len(rep.SourceFiles, 4)
+
+	sf := rep.SourceFiles["/Users/markbates/Dropbox/development/php-test-reporter/src/ConsoleCommands/SelfUpdateCommand.php"]
+	r.InDelta(15.2, sf.CoveredPercent, 1)
+	r.Len(sf.Coverage, 80)
+	r.False(sf.Coverage[2].Valid)
+	r.True(sf.Coverage[43].Valid)
+	r.Equal(0, sf.Coverage[38].Int)
+	r.Equal(5, sf.Coverage[62].Int)
 }

--- a/formatters/clover/example_without_package.xml
+++ b/formatters/clover/example_without_package.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage generated="1493754316">
+  <project timestamp="1493754316">
+    <file name="/Users/markbates/Dropbox/development/php-test-reporter/src/ConsoleCommands/RollbackCommand.php">
+      <class name="RollbackCommand" namespace="CodeClimate\PhpTestReporter\ConsoleCommands" fullPackage="CodeClimate" package="CodeClimate">
+        <metrics methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="18" coveredstatements="0" elements="20" coveredelements="0" />
+      </class>
+      <line num="22" type="method" name="configure" crap="2" count="0" />
+      <line num="23" type="stmt" count="1" />
+      <line num="24" type="stmt" count="1" />
+      <line num="25" type="stmt" count="1" />
+      <line num="27" type="method" name="execute" crap="6" count="1" />
+      <line num="28" type="stmt" count="1" />
+      <line num="29" type="stmt" count="1" />
+      <line num="30" type="stmt" count="1" />
+      <line num="31" type="stmt" count="1" />
+      <line num="34" type="stmt" count="0" />
+      <line num="36" type="stmt" count="0" />
+      <line num="37" type="stmt" count="0" />
+      <line num="38" type="stmt" count="0" />
+      <line num="40" type="stmt" count="0" />
+      <line num="41" type="stmt" count="0" />
+      <line num="42" type="stmt" count="0" />
+      <line num="43" type="stmt" count="0" />
+      <line num="44" type="stmt" count="0" />
+      <line num="46" type="stmt" count="0" />
+      <line num="47" type="stmt" count="0" />
+      <metrics loc="48" ncloc="40" classes="1" methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="18" coveredstatements="0" elements="20" coveredelements="0" />
+    </file>
+    <file name="/Users/markbates/Dropbox/development/php-test-reporter/src/ConsoleCommands/SelfUpdateCommand.php">
+      <class name="SelfUpdateCommand" namespace="CodeClimate\PhpTestReporter\ConsoleCommands" fullPackage="CodeClimate" package="CodeClimate">
+        <metrics methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="0" elements="46" coveredelements="0" />
+      </class>
+      <line num="24" type="method" name="configure" crap="2" count="0" />
+      <line num="25" type="stmt" count="0" />
+      <line num="26" type="stmt" count="1" />
+      <line num="27" type="stmt" count="1" />
+      <line num="29" type="stmt" count="1" />
+      <line num="30" type="stmt" count="1" />
+      <line num="31" type="stmt" count="1" />
+      <line num="32" type="stmt" count="1" />
+      <line num="33" type="stmt" count="0" />
+      <line num="34" type="stmt" count="0" />
+      <line num="35" type="stmt" count="0" />
+      <line num="36" type="stmt" count="0" />
+      <line num="37" type="stmt" count="0" />
+      <line num="38" type="stmt" count="0" />
+      <line num="39" type="stmt" count="0" />
+      <line num="40" type="stmt" count="0" />
+      <line num="41" type="stmt" count="0" />
+      <line num="43" type="method" name="execute" crap="30" count="0" />
+      <line num="44" type="stmt" count="0" />
+      <line num="45" type="stmt" count="0" />
+      <line num="46" type="stmt" count="0" />
+      <line num="49" type="stmt" count="0" />
+      <line num="51" type="stmt" count="0" />
+      <line num="52" type="stmt" count="0" />
+      <line num="53" type="stmt" count="0" />
+      <line num="55" type="stmt" count="0" />
+      <line num="56" type="stmt" count="0" />
+      <line num="58" type="stmt" count="0" />
+      <line num="59" type="stmt" count="0" />
+      <line num="60" type="stmt" count="0" />
+      <line num="62" type="stmt" count="0" />
+      <line num="63" type="stmt" count="5" />
+      <line num="65" type="stmt" count="0" />
+      <line num="66" type="stmt" count="0" />
+      <line num="67" type="stmt" count="0" />
+      <line num="68" type="stmt" count="0" />
+      <line num="69" type="stmt" count="0" />
+      <line num="70" type="stmt" count="0" />
+      <line num="71" type="stmt" count="0" />
+      <line num="72" type="stmt" count="0" />
+      <line num="74" type="stmt" count="0" />
+      <line num="75" type="stmt" count="0" />
+      <line num="76" type="stmt" count="0" />
+      <line num="78" type="stmt" count="0" />
+      <line num="79" type="stmt" count="0" />
+      <line num="80" type="stmt" count="0" />
+      <metrics loc="81" ncloc="73" classes="1" methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="0" elements="46" coveredelements="0" />
+    </file>
+    <file name="/Users/markbates/Dropbox/development/php-test-reporter/src/ConsoleCommands/UploadCommand.php">
+      <class name="UploadCommand" namespace="CodeClimate\PhpTestReporter\ConsoleCommands">
+        <metrics methods="2" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="29" coveredstatements="18" elements="31" coveredelements="19" />
+      </class>
+      <line num="17" type="method" name="configure" crap="1" count="1" />
+      <line num="20" type="stmt" count="1" />
+      <line num="21" type="stmt" count="1" />
+      <line num="22" type="stmt" count="1" />
+      <line num="23" type="stmt" count="1" />
+      <line num="24" type="stmt" count="1" />
+      <line num="25" type="stmt" count="1" />
+      <line num="27" type="stmt" count="1" />
+      <line num="28" type="stmt" count="1" />
+      <line num="29" type="stmt" count="1" />
+      <line num="30" type="stmt" count="1" />
+      <line num="31" type="stmt" count="1" />
+      <line num="32" type="stmt" count="1" />
+      <line num="34" type="stmt" count="1" />
+      <line num="36" type="method" name="execute" crap="9.20" count="1" />
+      <line num="38" type="stmt" count="1" />
+      <line num="39" type="stmt" count="1" />
+      <line num="41" type="stmt" count="1" />
+      <line num="42" type="stmt" count="1" />
+      <line num="44" type="stmt" count="1" />
+      <line num="47" type="stmt" count="0" />
+      <line num="48" type="stmt" count="0" />
+      <line num="50" type="stmt" count="0" />
+      <line num="51" type="stmt" count="0" />
+      <line num="53" type="stmt" count="0" />
+      <line num="56" type="stmt" count="0" />
+      <line num="57" type="stmt" count="0" />
+      <line num="59" type="stmt" count="0" />
+      <line num="62" type="stmt" count="0" />
+      <line num="63" type="stmt" count="0" />
+      <line num="65" type="stmt" count="0" />
+      <metrics loc="67" ncloc="64" classes="1" methods="2" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="29" coveredstatements="18" elements="31" coveredelements="19" />
+    </file>
+    <file name="/Users/markbates/Dropbox/development/php-test-reporter/src/System/Git/GitInfoInterface.php">
+      <metrics loc="29" ncloc="14" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0" />
+    </file>
+    <metrics files="13" loc="937" ncloc="722" classes="12" methods="49" coveredmethods="37" conditionals="0" coveredconditionals="0" statements="306" coveredstatements="148" elements="355" coveredelements="185" />
+  </project>
+</coverage>

--- a/formatters/clover/xml.go
+++ b/formatters/clover/xml.go
@@ -3,15 +3,18 @@ package clover
 import "encoding/xml"
 
 type xmlFile struct {
+	Name  string `xml:"name,attr"`
+	Lines []struct {
+		Num   int `xml:"num,attr"`
+		Count int `xml:"count,attr"`
+	} `xml:"line"`
+}
+
+type xmlClover struct {
 	XMLName  xml.Name `xml:"coverage"`
 	Packages []struct {
-		Name  string `xml:"name,attr"`
-		Files []struct {
-			Name  string `xml:"name,attr"`
-			Lines []struct {
-				Num   int `xml:"num,attr"`
-				Count int `xml:"count,attr"`
-			} `xml:"line"`
-		} `xml:"file"`
+		Name  string    `xml:"name,attr"`
+		Files []xmlFile `xml:"file"`
 	} `xml:"project>package"`
+	Files []xmlFile `xml:"project>file"`
 }


### PR DESCRIPTION
Clover formatter was expecting coverage data to look like: 
```
<coverage generated="11111">
  <project timestamp="111111">
    <package>
      <file name="path1">
        <line num="23" type="stmt" count="0"/>
      </file>
      <file name="path2">
        <line num="2" type="stmt" count="0"/>
      </file>
    </package>
  </project>
</coverage>
```
But a valid syntax is to also have files without the `package` tag wrapping them, like this: 
```
<coverage generated="11111">
  <project timestamp="111111">
    <file name="path1">
      <line num="23" type="stmt" count="0"/>
    </file>
    <file name="path2">
      <line num="2" type="stmt" count="0"/>
    </file>
  </project>
</coverage>
```

This PR adds supports for that 