### PR TITLE
Raise an error when report is empty

### DIFF
--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -105,6 +105,10 @@ func (f CoverageFormatter) Save() error {
 		return errors.WithStack(err)
 	}
 
+	if len(rep.SourceFiles) == 0 {
+		return errors.WithStack(errors.New("Empty report. Could not find coverage info for source files"))
+	}
+
 	if f.writer == nil {
 		f.writer, err = writer(formatOptions.Output)
 		if err != nil {

--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -106,7 +106,7 @@ func (f CoverageFormatter) Save() error {
 	}
 
 	if len(rep.SourceFiles) == 0 {
-		return errors.WithStack(errors.New("Empty report. Could not find coverage info for source files"))
+		return errors.WithStack(errors.New("could not find coverage info for source files"))
 	}
 
 	if f.writer == nil {

--- a/cmd/format-coverage_test.go
+++ b/cmd/format-coverage_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/codeclimate/test-reporter/formatters/clover"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CoverageFormatter_Save_Fail_On_Empty_Report(t *testing.T) {
+	r := require.New(t)
+	a := CoverageFormatter{}
+	a.In = &clover.Formatter{}
+	a.In.Search("../formatters/clover/empty_example.xml")
+
+	err := a.Save()
+	r.Error(err)
+	r.Equal("could not find coverage info for source files", err.Error())
+}

--- a/formatters/clover/empty_example.xml
+++ b/formatters/clover/empty_example.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage generated="1493754316">
+  <project timestamp="1493754316">
+    <metrics files="13" loc="937" ncloc="722" classes="12" methods="49" coveredmethods="37" conditionals="0" coveredconditionals="0" statements="306" coveredstatements="148" elements="355" coveredelements="185" />
+  </project>
+</coverage>


### PR DESCRIPTION
Currently if report is empty after formatting, it will create a `codeclimate.json` without any source files. And it won't give any feedback to the user about it. This behavior is confusing at that point we should raise an error so user is aware that something went wrong.  