### PR TITLE
Statically compile binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ build-docker:
 	  --env GOARCH \
 	  --env GOOS \
 	  --env GOPATH=/ \
+	  --env CGO_ENABLED=0 \
 	  --volume "$(PWD)"/artifacts:/artifacts \
 	  --volume "$(PWD)":"/src/$(PROJECT)":ro \
 	  --workdir "/src/$(PROJECT)" \


### PR DESCRIPTION
* test-reporter does not work on some alpine based images because
  go compiler does not statically link unless you're cross compiling.

More details https://golang.org/cmd/cgo/#hdr-Using_cgo_with_the_go_command