### PR TITLE
Fix jacoco formatter

### DIFF
--- a/formatters/jacoco/jacoco.go
+++ b/formatters/jacoco/jacoco.go
@@ -2,6 +2,7 @@ package jacoco
 
 import (
 	"encoding/xml"
+	"fmt"
 	"os"
 	"strings"
 
@@ -41,21 +42,22 @@ func (r Formatter) Format() (formatters.Report, error) {
 		return rep, errors.WithStack(err)
 	}
 
-	c := &xmlFile{}
-	err = xml.NewDecoder(fx).Decode(c)
+	xmlJacoco := &xmlFile{}
+	err = xml.NewDecoder(fx).Decode(xmlJacoco)
 	if err != nil {
 		return rep, errors.WithStack(err)
 	}
 
 	gitHead, _ := env.GetHead()
-	for _, pp := range c.Packages {
-		for _, pf := range pp.SourceFile {
+	for _, xmlPackage := range xmlJacoco.Packages {
+		for _, xmlSF := range xmlPackage.SourceFile {
 			num := 1
-			sf, err := formatters.NewSourceFile(pf.Name, gitHead)
+			filepath := fmt.Sprintf("%s/%s", xmlPackage.Name, xmlSF.Name)
+			sf, err := formatters.NewSourceFile(filepath, gitHead)
 			if err != nil {
 				return rep, errors.WithStack(err)
 			}
-			for _, l := range pf.Lines {
+			for _, l := range xmlSF.Lines {
 				for num < l.Num {
 					sf.Coverage = append(sf.Coverage, formatters.NullInt{})
 					num++

--- a/formatters/jacoco/jacoco_test.go
+++ b/formatters/jacoco/jacoco_test.go
@@ -23,7 +23,7 @@ func Test_Parse(t *testing.T) {
 	r.NoError(err)
 	r.Len(rep.SourceFiles, 3)
 
-	sf := rep.SourceFiles["Application.java"]
+	sf := rep.SourceFiles["be/apo/basic/Application.java"]
 	r.InDelta(33.3, sf.CoveredPercent, 1)
 	r.Len(sf.Coverage, 11)
 	r.True(sf.Coverage[6].Valid)


### PR DESCRIPTION
* Jacoco formatter was not taking into account the package
  name to create the source file path.
* Update test to check for full filepath