### PR TITLE
Do nothing when --add-prefix is empty string

### DIFF
--- a/formatters/source_file.go
+++ b/formatters/source_file.go
@@ -75,8 +75,10 @@ func NewSourceFile(name string, commit *object.Commit) (SourceFile, error) {
 	if prefix, err := envy.MustGet("PREFIX"); err == nil {
 		if strings.HasSuffix(prefix, string(os.PathSeparator)) {
 			name = strings.TrimPrefix(name, prefix)
+			logrus.Printf("triming with prefix %s\n", prefix)
 		} else {
-			prefix := fmt.Sprintf("%s%s", prefix, string(os.PathSeparator))
+			prefix = fmt.Sprintf("%s%s", prefix, string(os.PathSeparator))
+			logrus.Printf("triming with prefix %s\n", prefix)
 			name = strings.TrimPrefix(name, prefix)
 		}
 	}
@@ -94,10 +96,12 @@ func NewSourceFile(name string, commit *object.Commit) (SourceFile, error) {
 	}
 
 	if addPrefix, err := envy.MustGet("ADD_PREFIX"); err == nil {
-		if strings.HasSuffix(addPrefix, string(os.PathSeparator)) {
-			sf.Name = addPrefix + sf.Name
-		} else {
-			sf.Name = addPrefix + string(os.PathSeparator) + sf.Name
+		if addPrefix != "" {
+			if strings.HasSuffix(addPrefix, string(os.PathSeparator)) {
+				sf.Name = addPrefix + sf.Name
+			} else {
+				sf.Name = addPrefix + string(os.PathSeparator) + sf.Name
+			}
 		}
 	}
 

--- a/formatters/source_file_test.go
+++ b/formatters/source_file_test.go
@@ -98,3 +98,14 @@ func Test_SourceFilePrefixWithPathSeparator(t *testing.T) {
 		r.Equal(sf.Name, "coverage.go")
 	})
 }
+
+func Test_SourceFileEmptyAddPrefixDoesNothing(t *testing.T) {
+	envy.Temp(func() {
+		envy.Set("PREFIX", "./")
+		envy.Set("ADD_PREFIX", "")
+		r := require.New(t)
+		sf, err := NewSourceFile("./coverage.go", nil)
+		r.NoError(err)
+		r.Equal(sf.Name, "coverage.go")
+	})
+}


### PR DESCRIPTION
By default `--add-prefix` is an empty string, in those cases we shouldn't do anything.