### PR TITLE
Add sources to coverage.py formatter

### DIFF
--- a/formatters/coveragepy/xml.go
+++ b/formatters/coveragepy/xml.go
@@ -1,9 +1,18 @@
 package coveragepy
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+)
+
+type Source struct {
+	Path string `xml:",chardata"`
+}
 
 type xmlFile struct {
 	XMLName  xml.Name `xml:"coverage"`
+	Sources  []Source `xml:"sources>source"`
 	Packages []struct {
 		Name    string `xml:"name,attr"`
 		Classes []struct {
@@ -14,4 +23,17 @@ type xmlFile struct {
 			} `xml:"lines>line"`
 		} `xml:"classes>class"`
 	} `xml:"packages>package"`
+}
+
+func (covpyFile xmlFile) getFullFilePath(filename string) string {
+	fullFilePath := filename
+
+	for _, source := range covpyFile.Sources {
+		filepath := fmt.Sprintf("%s/%s", source.Path, filename)
+		if _, err := os.Stat(filepath); err == nil {
+			fullFilePath = filepath
+			break
+		}
+	}
+	return fullFilePath
 }

--- a/integration-tests/coverage_py/Dockerfile
+++ b/integration-tests/coverage_py/Dockerfile
@@ -29,7 +29,8 @@ RUN git config --global user.name "Your Name"
 RUN git add ignore.me
 RUN git commit -m "testing"
 
+WORKDIR ..
 ENV CC_TEST_REPORTER_ID=c4881e09870b0fac1291c93339b36ffe36210a2645c1ad25e52d8fda3943fb4d
-RUN test-reporter format-coverage -d
+RUN test-reporter format-coverage -d -t coverage.py python-test-reporter/coverage.xml
 RUN cat coverage/codeclimate.json
 RUN test-reporter upload-coverage -d -s 2


### PR DESCRIPTION
- coverage.py formatter was not parsing <source> tags. Making
  format-coverage to fail when it was run in a different working
  directory to the directory the tests ran
- Updates integration-test for coverage.py so it runs on a
  different working directory.

Addresses https://github.com/codeclimate/test-reporter/issues/242