### PR TITLE
Correct multiple builds documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ suite's results into one final report.
 1. After all test suites, run:
 
   ```sh
-  ./cc-test-reporter sum-coverage coverage/codeclimate.*.json | \
-    ./cc-test-reporter upload-coverage
+  ./cc-test-reporter sum-coverage coverage/codeclimate.*.json
+  ./cc-test-reporter upload-coverage
   ```
 
 ## Copyright


### PR DESCRIPTION
💁 These changes correct the example steps run after multiple builds. They should run separately, not in a chain.