### PR TITLE
Treat 409 upload status as warning, not error

### DIFF
--- a/integration-tests/simplecov/Dockerfile
+++ b/integration-tests/simplecov/Dockerfile
@@ -36,3 +36,7 @@ RUN test-reporter after-build -s 5 -d
 # RUN mv coverage custom-coverage
 # RUN test-reporter format-coverage -d -t simplecov custom-coverage/.resultset.json
 # RUN test-reporter upload-coverage -d -s 5
+
+# test coverage on conflict uploads
+# RUN test-reporter after-build -s 5 -d
+# RUN test-reporter after-build -s 5 -d


### PR DESCRIPTION
Depending on CI setup, it is possible that CI can run multiple times for
the same commit. The `v1/test_reports` endpoint returns 409 when
receiving a request to create a test report when one already exists for
the commit. This exception currently is bubbled through the reporter
causing the run to ultimately exit with non-zero code.

This changes the behavior to treat the 409 status separately as a
"warning" rather than an "error," which better reflects the situation.
The exit status in this case will be 0 and a warning will be logged.

Another alternative considered was changing the endpoint to be
create-or-update, but that has been deferred for now.

before:
```
Error: response from https://api.codeclimate.com/v1/test_reports.
HTTP 409: A test report for commit cf4f59d96036b8e01e87934a1882f949681dcfa5 already exists
Usage:
  cc-test-reporter after-build [flags]
...
```

after:
```
time="2017-12-04T19:32:32Z" level=warning msg="Conflict when uploading: A test report for commit 6295df9ddd0bc327d2d16c96aee1f4fee7d247b4 already exists, skipping upload"
```