### PR TITLE
Few fixes

### DIFF
--- a/examples/go_examples.md
+++ b/examples/go_examples.md
@@ -113,17 +113,15 @@ language: go
 go:
   - 1.9
 install:
-  - go get -v github.com/golang/dep/cmd/dep
   - go get -v github.com/codeclimate/test-reporter
-  - cd $GOPATH/src/github.com/golang/dep/cmd/dep && git checkout tags/v0.4.1 && go install
   - cd $GOPATH/src/github.com/codeclimate/test-reporter && git checkout tags/v0.4.3 && go install
-  - cd $GOPATH/src/github.com/user/project && dep ensure -v -vendor-only
+  - cd -
 before_script:
   - test-reporter before-build
 script:
   - go test -coverprofile c.out -coverpkg ./...
 after_script:
-  - test-reporter after-build --cover-input-type gocov --exit-code $TRAVIS_TEST_RESULT
+  - test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 env:
   global:
     - secure: [REDACTED]

--- a/examples/go_examples.md
+++ b/examples/go_examples.md
@@ -117,13 +117,13 @@ install:
   - go get -v github.com/codeclimate/test-reporter
   - cd $GOPATH/src/github.com/golang/dep/cmd/dep && git checkout tags/v0.4.1 && go install
   - cd $GOPATH/src/github.com/codeclimate/test-reporter && git checkout tags/v0.4.3 && go install
-  - cd - && dep ensure -v -vendor-only
+  - cd $GOPATH/src/github.com/user/project && dep ensure -v -vendor-only
 before_script:
   - test-reporter before-build
 script:
-  - go test -coverprofile c.out
+  - go test -coverprofile c.out -coverpkg ./...
 after_script:
-  - test-reporter after-build --input-type gocov --exit-code $TRAVIS_TEST_RESULT
+  - test-reporter after-build --cover-input-type gocov --exit-code $TRAVIS_TEST_RESULT
 env:
   global:
     - secure: [REDACTED]


### PR DESCRIPTION
Use `--cover-input-type` and not `--input-type`. 

Replace `cd -` which didn't have the expected behaviour.

Add `coverpkg ./...` to test all packages. This needs to be specified when using `-coverprofile`.