### PR TITLE
Add flag to upload coverage insecurely

### DIFF
--- a/cmd/after-build.go
+++ b/cmd/after-build.go
@@ -20,6 +20,7 @@ var afterBuildOptions = struct {
 	EndpointURL string
 	ReporterID  string
 	ExitCode    int
+	Insecure    bool
 }{}
 
 var afterBuildCmd = &cobra.Command{
@@ -49,6 +50,7 @@ var afterBuildCmd = &cobra.Command{
 			ReporterID:  afterBuildOptions.ReporterID,
 			EndpointURL: afterBuildOptions.EndpointURL,
 			BatchSize:   afterBuildOptions.BatchSize,
+			Insecure:    afterBuildOptions.Insecure,
 		}
 
 		logrus.Debug("about to run upload-coverage")
@@ -64,5 +66,6 @@ func init() {
 	afterBuildCmd.Flags().StringVarP(&afterBuildOptions.ReporterID, "id", "r", os.Getenv("CC_TEST_REPORTER_ID"), "reporter identifier")
 	afterBuildCmd.Flags().StringVarP(&afterBuildOptions.EndpointURL, "coverage-endpoint", "e", envy.Get("CC_TEST_REPORTER_COVERAGE_ENDPOINT", "https://api.codeclimate.com/v1/test_reports"), "endpoint to upload coverage information to")
 	afterBuildCmd.Flags().IntVarP(&afterBuildOptions.BatchSize, "batch-size", "s", 500, "batch size for source files")
+	afterBuildCmd.Flags().BoolVar(&afterBuildOptions.Insecure, "insecure", false, "send coverage insecurely (without HTTPS)")
 	RootCmd.AddCommand(afterBuildCmd)
 }

--- a/cmd/upload-coverage.go
+++ b/cmd/upload-coverage.go
@@ -35,5 +35,7 @@ func init() {
 	uploadCoverageCmd.Flags().StringVarP(&uploadOptions.ReporterID, "id", "r", os.Getenv("CC_TEST_REPORTER_ID"), "reporter identifier")
 	uploadCoverageCmd.Flags().StringVarP(&uploadOptions.EndpointURL, "endpoint", "e", envy.Get("CC_TEST_REPORTER_COVERAGE_ENDPOINT", "https://api.codeclimate.com/v1/test_reports"), "endpoint to upload coverage information to")
 	uploadCoverageCmd.Flags().IntVarP(&uploadOptions.BatchSize, "batch-size", "s", 500, "batch size for source files")
+	uploadCoverageCmd.Flags().BoolVar(&uploadOptions.Insecure, "insecure", false, "send coverage insecurely (without HTTPS)")
+
 	RootCmd.AddCommand(uploadCoverageCmd)
 }

--- a/upload/uploader_test.go
+++ b/upload/uploader_test.go
@@ -1,0 +1,48 @@
+package upload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TransformPostBatchURL_Secure(t *testing.T) {
+	r := require.New(t)
+
+	uploader := Uploader{
+		Insecure: false,
+	}
+
+	rawURL := "https://example.com/"
+	actualURL, err := uploader.TransformPostBatchURL(rawURL)
+
+	r.Equal("https://example.com/", actualURL)
+	r.Nil(err)
+}
+func Test_TransformPostBatchURL_Insecure_Success(t *testing.T) {
+	r := require.New(t)
+
+	uploader := Uploader{
+		Insecure: true,
+	}
+
+	rawURL := "https://example.com/"
+	actualURL, err := uploader.TransformPostBatchURL(rawURL)
+
+	r.Equal("http://example.com/", actualURL)
+	r.Nil(err)
+}
+
+func Test_TransformPostBatchURL_Insecure_Error(t *testing.T) {
+	r := require.New(t)
+
+	uploader := Uploader{
+		Insecure: true,
+	}
+
+	rawURL := "://example.com/"
+	actualURL, err := uploader.TransformPostBatchURL(rawURL)
+
+	r.Equal("", actualURL)
+	r.Equal("parse ://example.com/: missing protocol scheme", err.Error())
+}


### PR DESCRIPTION
Add an `--insecure` flag to both the `after-build` and `upload-coverage` sub-commands to upload test coverage insecurely (without HTTPS).

This is *not* recommended for general use. This is intended for use in private environments where the benefits of secure transfer outweigh the operational costs.