### PR TITLE
Add optional JACOCO_SOURCE_PATH env variable

### DIFF
--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -52,7 +52,7 @@ var formatterMap = map[string]formatters.Formatter{
 
 // formatCoverageCmd represents the format command
 var formatCoverageCmd = &cobra.Command{
-	Use:   "format-coverage",
+	Use:   "format-coverage [coverage file]",
 	Short: "Locate, parse, and re-format supported coverage sources.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {

--- a/formatters/jacoco/jacoco.go
+++ b/formatters/jacoco/jacoco.go
@@ -4,15 +4,21 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codeclimate/test-reporter/env"
 	"github.com/codeclimate/test-reporter/formatters"
+	"github.com/gobuffalo/envy"
 	"github.com/pkg/errors"
 )
 
 var searchPaths = []string{"jacoco.xml"}
+
+func getSourcePath() string {
+	return envy.Get("JACOCO_SOURCE_PATH", "")
+}
 
 type Formatter struct {
 	Path string
@@ -32,6 +38,8 @@ func (f *Formatter) Search(paths ...string) (string, error) {
 }
 
 func (r Formatter) Format() (formatters.Report, error) {
+	sourcePath := getSourcePath()
+
 	rep, err := formatters.NewReport()
 	if err != nil {
 		return rep, err
@@ -53,7 +61,7 @@ func (r Formatter) Format() (formatters.Report, error) {
 		for _, xmlSF := range xmlPackage.SourceFile {
 			num := 1
 			filepath := fmt.Sprintf("%s/%s", xmlPackage.Name, xmlSF.Name)
-			sf, err := formatters.NewSourceFile(filepath, gitHead)
+			sf, err := formatters.NewSourceFile(path.Join(sourcePath, filepath), gitHead)
 			if err != nil {
 				return rep, errors.WithStack(err)
 			}

--- a/formatters/jacoco/jacoco_test.go
+++ b/formatters/jacoco/jacoco_test.go
@@ -6,6 +6,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 
 	"github.com/codeclimate/test-reporter/env"
+	"github.com/codeclimate/test-reporter/formatters"
+	"github.com/gobuffalo/envy"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +26,34 @@ func Test_Parse(t *testing.T) {
 	r.Len(rep.SourceFiles, 3)
 
 	sf := rep.SourceFiles["be/apo/basic/Application.java"]
+	r.InDelta(33.3, sf.CoveredPercent, 1)
+	r.Len(sf.Coverage, 11)
+	r.True(sf.Coverage[6].Valid)
+	r.False(sf.Coverage[8].Valid)
+	r.Equal(3, sf.Coverage[6].Int)
+	r.Equal(0, sf.Coverage[8].Int)
+}
+
+func Test_Parse_SourcePath(t *testing.T) {
+	gb := env.GitBlob
+	defer func() { env.GitBlob = gb }()
+	env.GitBlob = func(s string, c *object.Commit) (string, error) {
+		return s, nil
+	}
+
+	r := require.New(t)
+
+	f := &Formatter{Path: "./example.xml"}
+	var rep formatters.Report
+	var err error
+	envy.Temp(func() {
+		envy.Set("JACOCO_SOURCE_PATH", "src/main/java")
+		rep, err = f.Format()
+	})
+	r.NoError(err)
+	r.Len(rep.SourceFiles, 3)
+
+	sf := rep.SourceFiles["src/main/java/be/apo/basic/Application.java"]
 	r.InDelta(33.3, sf.CoveredPercent, 1)
 	r.Len(sf.Coverage, 11)
 	r.True(sf.Coverage[6].Valid)


### PR DESCRIPTION
Add an optional `JACOCO_SOURCE_PATH` environment variable to fix bug where sometimes the path to source code can't be inferred.

Example usage:

    JACOCO_SOURCE_PATH=src/main/java ./cc-test-reporter \
      format-coverage target/site/jacoco/jacoco.xml     \
      --input-type jacoco

Addresses #259.