### PR TITLE
Ignore invalid lines in cobertuna formatter

### DIFF
--- a/formatters/cobertura/cobertura.go
+++ b/formatters/cobertura/cobertura.go
@@ -74,17 +74,21 @@ func (r Formatter) Format() (formatters.Report, error) {
 			}
 			sort.Sort(ByLineNum(pf.Lines))
 			for _, l := range pf.Lines {
-				for num < l.Num {
-					sf.Coverage = append(sf.Coverage, formatters.NullInt{})
-					num++
-				}
-				if l.Num <= len(sf.Coverage) {
-					hits := sf.Coverage[l.Num-1].Int + l.Hits
-					sf.Coverage[l.Num-1] = formatters.NewNullInt(hits)
+				if l.Num > 0 {
+					for num < l.Num {
+						sf.Coverage = append(sf.Coverage, formatters.NullInt{})
+						num++
+					}
+					if l.Num <= len(sf.Coverage) {
+						hits := sf.Coverage[l.Num-1].Int + l.Hits
+						sf.Coverage[l.Num-1] = formatters.NewNullInt(hits)
+					} else {
+						ni := formatters.NewNullInt(l.Hits)
+						sf.Coverage = append(sf.Coverage, ni)
+						num++
+					}
 				} else {
-					ni := formatters.NewNullInt(l.Hits)
-					sf.Coverage = append(sf.Coverage, ni)
-					num++
+					logrus.Warnf("Invalid line number %d in file %s", l.Num, fileName)
 				}
 			}
 			err = rep.AddSourceFile(sf)

--- a/formatters/cobertura/example.xml
+++ b/formatters/cobertura/example.xml
@@ -115,6 +115,7 @@
             <line number="20" hits="5" branch="false" />
             <line number="31" hits="3" branch="false" />
             <line number="20" hits="7" branch="false" />
+            <line number="0" hits="3" branch="false" />
           </lines>
         </class>
         <class name="search.ISortedArraySearch" filename="search/ISortedArraySearch.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">


### PR DESCRIPTION
This prevents the test reporter from crashing when an invalid line
number is detected in the cobertuna.xml coverage file.

While this does not address the actual issue causing invalid line
numbers, it does allow the test reporter to ignore the invalid lines.

Related: https://github.com/SlatherOrg/slather/pull/387
Addresses: https://github.com/codeclimate/test-reporter/issues/320