### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## v0.5.2 [(2018-05-15)](https://github.com/codeclimate/test-reporter/releases/tag/v0.5.2)
+
+* [FIX] Update `Cobertura` formatter to ignore invalid line numbers in a
+  `cobertura.xml` file [#335][]
+
+[#335]: https://github.com/codeclimate/test-reporter/pull/335
+
 ## v0.5.1 [(2018-03-19)](https://github.com/codeclimate/test-reporter/releases/tag/v0.5.1)
 
 * [FIX] Fix bug with formatting JaCoCo test coverage [#318][]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAN_FILES = $(wildcard man/*.md)
 MAN_PAGES = $(patsubst man/%.md,man/%,$(MAN_FILES))
 
 PROJECT = github.com/codeclimate/test-reporter
-VERSION ?= 0.5.1
+VERSION ?= 0.5.2
 BUILD_VERSION = $(shell git log -1 --pretty=format:'%H')
 BUILD_TIME = $(shell date +%FT%T%z)
 LDFLAGS = -ldflags "-X $(PROJECT)/version.Version=${VERSION} -X $(PROJECT)/version.BuildVersion=${BUILD_VERSION} -X $(PROJECT)/version.BuildTime=${BUILD_TIME}"


### PR DESCRIPTION
* [FIX] Update `Cobertura` formatter to ignore invalid line numbers in a
  `cobertura.xml` file #335