### PR TITLE
Fix gcov formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ test-lcov:
 test-covpy:
 	docker build -f integration-tests/coverage_py/Dockerfile .
 
+test-gcov:
+	docker build -f integration-tests/gcov/Dockerfile .
+
 test-gocov:
 	docker build -f integration-tests/gocov/Dockerfile .
 

--- a/formatters/gcov/examples/Calculator.swift
+++ b/formatters/gcov/examples/Calculator.swift
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <string.h>
+
+int compute(char* alpha, char* beta) {
+	int distance = 0;
+	int len = strlen(alpha)<strlen(beta) ? strlen(alpha) : strlen(beta);
+
+	for(int i=0; i<len; i++) {
+		if(alpha[i] != beta[i]) {
+			distance++;
+		}
+	}
+
+	return distance;
+}
+
+int main() {
+	if(compute("", "AAGC") != 0) {
+		printf("Test failed");
+	}
+
+	if(compute("AGA", "AGC") != 1) {
+		printf("Test failed");
+	}
+}

--- a/formatters/gcov/examples/Calculator.swift.gcov
+++ b/formatters/gcov/examples/Calculator.swift.gcov
@@ -1,4 +1,4 @@
-    -:    0:Source:/Users/katsumi/Dropbox/Xcode Projects/SwiftCov/Examples/ExampleFramework/ExampleFramework/Calculator.swift
+    -:    0:Source:examples/Calculator.swift
     -:    0:Runs:1
     -:    0:Programs:1
     -:    1://

--- a/formatters/gcov/examples/Networking.swift
+++ b/formatters/gcov/examples/Networking.swift
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <string.h>
+
+int compute(char* alpha, char* beta) {
+	int distance = 0;
+	int len = strlen(alpha)<strlen(beta) ? strlen(alpha) : strlen(beta);
+
+	for(int i=0; i<len; i++) {
+		if(alpha[i] != beta[i]) {
+			distance++;
+		}
+	}
+
+	return distance;
+}
+
+int main() {
+	if(compute("", "AAGC") != 0) {
+		printf("Test failed");
+	}
+
+	if(compute("AGA", "AGC") != 1) {
+		printf("Test failed");
+	}
+}

--- a/formatters/gcov/examples/Networking.swift.gcov
+++ b/formatters/gcov/examples/Networking.swift.gcov
@@ -1,4 +1,4 @@
-    -:    0:Source:/Users/katsumi/Dropbox/Xcode Projects/SwiftCov/Examples/ExampleFramework/ExampleFramework/Networking.swift
+    -:    0:Source:examples/Networking.swift
     -:    0:Runs:1
     -:    0:Programs:1
     -:    1://

--- a/formatters/gcov/examples/hamming.c.gcov
+++ b/formatters/gcov/examples/hamming.c.gcov
@@ -1,4 +1,4 @@
-        -:    0:Source:hamming.c
+        -:    0:Source:examples/hamming.c
         -:    0:Graph:hamming.gcno
         -:    0:Data:hamming.gcda
         -:    0:Runs:1
@@ -35,7 +35,7 @@ branch  2 taken 100%
     #####:   19:		printf("Test failed");
 call    0 never executed
         -:   20:	}
-        -:   21:	
+        -:   21:
         1:   22:	if(compute("AGA", "AGC") != 1) {
 call    0 returned 100%
 branch  1 taken 0% (fallthrough)

--- a/formatters/gcov/gcov.go
+++ b/formatters/gcov/gcov.go
@@ -74,7 +74,7 @@ func (f *Formatter) Format() (formatters.Report, error) {
 // Parse a single GCov source file.
 func parseSourceFile(fileName string, gitHead *object.Commit) (formatters.SourceFile, error) {
 	var sf formatters.SourceFile
-	sourceFileName, err := getSourFileName(fileName)
+	sourceFileName, err := getSourceFileName(fileName)
 	if err != nil {
 		return sf, errors.WithStack(err)
 	}
@@ -124,7 +124,7 @@ func parseSourceFile(fileName string, gitHead *object.Commit) (formatters.Source
 	return sf, nil
 }
 
-func getSourFileName(coverageFileName string) (string, error) {
+func getSourceFileName(coverageFileName string) (string, error) {
 	coverageFile, err := os.Open(coverageFileName)
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/formatters/gcov/gcov_test.go
+++ b/formatters/gcov/gcov_test.go
@@ -17,13 +17,13 @@ func TestParse(t *testing.T) {
 	r.NoError(err)
 	r.Len(rep.SourceFiles, 3)
 
-	testCalculator(r, rep.SourceFiles["examples/Calculator.swift.gcov"])
-	testHamming(r, rep.SourceFiles["examples/hamming.c.gcov"])
+	testCalculator(r, rep.SourceFiles["examples/Calculator.swift"])
+	testHamming(r, rep.SourceFiles["examples/hamming.c"])
 	testReport(r, f)
 }
 
 func testCalculator(r *require.Assertions, sf formatters.SourceFile) {
-	r.Equal("examples/Calculator.swift.gcov", sf.Name)
+	r.Equal("examples/Calculator.swift", sf.Name)
 	r.InDelta(70.8, sf.CoveredPercent, 1)
 	r.Len(sf.Coverage, 61)
 	r.False(sf.Coverage[15].Valid)
@@ -35,7 +35,7 @@ func testCalculator(r *require.Assertions, sf formatters.SourceFile) {
 }
 
 func testHamming(r *require.Assertions, sf formatters.SourceFile) {
-	r.Equal("examples/hamming.c.gcov", sf.Name)
+	r.Equal("examples/hamming.c", sf.Name)
 	r.InDelta(83.3, sf.CoveredPercent, 1)
 	r.Len(sf.Coverage, 25)
 	r.False(sf.Coverage[2].Valid)


### PR DESCRIPTION
* Adds getSourFileName. Formatter will parse from coverage file
  the source file name, use it to create the SourceFile and
  then, add it to the Report.

* Updates specs and fixtures so we ensure that we're returning
  actual source file names and not coverage file names.

Addresses https://github.com/codeclimate/test-reporter/issues/328

Successful report uploaded [here](https://codeclimate.com/admin/repos/5237427489af7e354e011c77/test_reports/5aff3a65dae61039e7000131) using `make test-gcov`.