### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## v0.6.0 [(2018-05-21)](https://github.com/codeclimate/test-reporter/releases/tag/v0.6.0)
+
+* [FIX] Update `Gcov` formatter to report the correct source file paths [#338][]
+
+[#338]: https://github.com/codeclimate/test-reporter/pull/338
+
 ## v0.5.2 [(2018-05-15)](https://github.com/codeclimate/test-reporter/releases/tag/v0.5.2)
 
 * [FIX] Update `Cobertura` formatter to ignore invalid line numbers in a

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAN_FILES = $(wildcard man/*.md)
 MAN_PAGES = $(patsubst man/%.md,man/%,$(MAN_FILES))
 
 PROJECT = github.com/codeclimate/test-reporter
-VERSION ?= 0.5.2
+VERSION ?= 0.6.0
 BUILD_VERSION = $(shell git log -1 --pretty=format:'%H')
 BUILD_TIME = $(shell date +%FT%T%z)
 LDFLAGS = -ldflags "-X $(PROJECT)/version.Version=${VERSION} -X $(PROJECT)/version.BuildVersion=${BUILD_VERSION} -X $(PROJECT)/version.BuildTime=${BUILD_TIME}"


### PR DESCRIPTION
* [FIX] Update `Gcov` formatter to report the correct source file paths [#338][]

[#338]: https://github.com/codeclimate/test-reporter/pull/338