### PR TITLE
Support multiple jacoco source paths.

### DIFF
--- a/formatters/jacoco/jacoco_test.go
+++ b/formatters/jacoco/jacoco_test.go
@@ -61,3 +61,31 @@ func Test_Parse_SourcePath(t *testing.T) {
 	r.Equal(3, sf.Coverage[6].Int)
 	r.Equal(0, sf.Coverage[8].Int)
 }
+
+func Test_Parse_SourcePaths(t *testing.T) {
+	gb := env.GitBlob
+	defer func() { env.GitBlob = gb }()
+	env.GitBlob = func(s string, c *object.Commit) (string, error) {
+		return s, nil
+	}
+
+	r := require.New(t)
+
+	f := &Formatter{Path: "./example.xml"}
+	var rep formatters.Report
+	var err error
+	envy.Temp(func() {
+		envy.Set("JACOCO_SOURCE_PATH", "src/test/java src/main/java")
+		rep, err = f.Format()
+	})
+	r.NoError(err)
+	r.Len(rep.SourceFiles, 3)
+
+	sf := rep.SourceFiles["src/main/java/be/apo/basic/Application.java"]
+	r.InDelta(33.3, sf.CoveredPercent, 1)
+	r.Len(sf.Coverage, 11)
+	r.True(sf.Coverage[6].Valid)
+	r.False(sf.Coverage[8].Valid)
+	r.Equal(3, sf.Coverage[6].Int)
+	r.Equal(0, sf.Coverage[8].Int)
+}


### PR DESCRIPTION
Allow multiple source paths to be used as prefixes for source files found in jacoco reports.

This will identify and return the first prefix for which the source file path exists.