### PR TITLE
Support clover `path` attribute on file nodes in XML report

### DIFF
--- a/formatters/clover/clover.go
+++ b/formatters/clover/clover.go
@@ -56,7 +56,13 @@ func (r Formatter) Format() (formatters.Report, error) {
 
 	for _, pf := range files {
 		num := 1
-		sf, err := formatters.NewSourceFile(pf.Name, gitHead)
+
+		path := pf.Path
+		if len(path) == 0 {
+			path = pf.Name
+		}
+
+		sf, err := formatters.NewSourceFile(path, gitHead)
 		if err != nil {
 			return rep, errors.WithStack(err)
 		}

--- a/formatters/clover/xml.go
+++ b/formatters/clover/xml.go
@@ -4,6 +4,7 @@ import "encoding/xml"
 
 type xmlFile struct {
 	Name  string `xml:"name,attr"`
+	Path  string `xml:"path,attr"`
 	Lines []struct {
 		Num   int `xml:"num,attr"`
 		Count int `xml:"count,attr"`


### PR DESCRIPTION
The XML report generated by more recent versions of clover include the
full path to the file within a `path` attribute. The `name` attribute in
these reports contains just the filename without any directory
structure.

To support reading the source file, we'll need to reference this new
attribute.