### PR TITLE
Failing test demonstrating clover format parsing bug (unable to parse with wrapping metrics tag) [DO NOT MERGE]

### DIFF
--- a/formatters/clover/clover_test.go
+++ b/formatters/clover/clover_test.go
@@ -54,3 +54,26 @@ func Test_Parse_Without_Package(t *testing.T) {
 	r.Equal(0, sf.Coverage[38].Int)
 	r.Equal(5, sf.Coverage[62].Int)
 }
+
+func Test_Parse_With_Metrics(t *testing.T) {
+	gb := env.GitBlob
+	defer func() { env.GitBlob = gb }()
+	env.GitBlob = func(s string, c *object.Commit) (string, error) {
+		return s, nil
+	}
+
+	r := require.New(t)
+
+	f := &Formatter{Path: "./example_with_metrics.xml"}
+	rep, err := f.Format()
+	r.NoError(err)
+	r.Len(rep.SourceFiles, 4)
+
+	sf := rep.SourceFiles["/Users/markbates/Dropbox/development/php-test-reporter/src/ConsoleCommands/SelfUpdateCommand.php"]
+	r.InDelta(15.2, sf.CoveredPercent, 1)
+	r.Len(sf.Coverage, 80)
+	r.False(sf.Coverage[2].Valid)
+	r.True(sf.Coverage[43].Valid)
+	r.Equal(0, sf.Coverage[38].Int)
+	r.Equal(5, sf.Coverage[62].Int)
+}

--- a/formatters/clover/example_with_metrics.xml
+++ b/formatters/clover/example_with_metrics.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1536823740104" clover="3.2.0">
+  <project timestamp="1536823740104" name="All files">
+    <metrics methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="0" elements="46" coveredelements="0" >
+      <package name="frontend">
+        <file name="/Users/markbates/Dropbox/development/php-test-reporter/src/ConsoleCommands/SelfUpdateCommand.php">
+          <class name="SelfUpdateCommand" namespace="CodeClimate\PhpTestReporter\ConsoleCommands" fullPackage="CodeClimate" package="CodeClimate">
+            <metrics methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="0" elements="46" coveredelements="0" />
+          </class>
+          <line num="24" type="method" name="configure" crap="2" count="0" />
+          <line num="25" type="stmt" count="0" />
+          <line num="26" type="stmt" count="0" />
+          <line num="27" type="stmt" count="0" />
+          <line num="29" type="stmt" count="0" />
+          <line num="30" type="stmt" count="0" />
+          <line num="31" type="stmt" count="0" />
+          <line num="32" type="stmt" count="0" />
+          <line num="33" type="stmt" count="0" />
+          <line num="34" type="stmt" count="0" />
+          <line num="35" type="stmt" count="0" />
+          <line num="36" type="stmt" count="0" />
+          <line num="37" type="stmt" count="0" />
+          <line num="38" type="stmt" count="0" />
+          <line num="39" type="stmt" count="0" />
+          <line num="40" type="stmt" count="0" />
+          <line num="41" type="stmt" count="0" />
+          <line num="43" type="method" name="execute" crap="30" count="0" />
+          <line num="44" type="stmt" count="0" />
+          <line num="45" type="stmt" count="0" />
+          <line num="46" type="stmt" count="0" />
+          <line num="49" type="stmt" count="0" />
+          <line num="51" type="stmt" count="0" />
+          <line num="52" type="stmt" count="0" />
+          <line num="53" type="stmt" count="0" />
+          <line num="55" type="stmt" count="0" />
+          <line num="56" type="stmt" count="0" />
+          <line num="58" type="stmt" count="0" />
+          <line num="59" type="stmt" count="0" />
+          <line num="60" type="stmt" count="0" />
+          <line num="62" type="stmt" count="0" />
+          <line num="63" type="stmt" count="0" />
+          <line num="65" type="stmt" count="0" />
+          <line num="66" type="stmt" count="0" />
+          <line num="67" type="stmt" count="0" />
+          <line num="68" type="stmt" count="0" />
+          <line num="69" type="stmt" count="0" />
+          <line num="70" type="stmt" count="0" />
+          <line num="71" type="stmt" count="0" />
+          <line num="72" type="stmt" count="0" />
+          <line num="74" type="stmt" count="0" />
+          <line num="75" type="stmt" count="0" />
+          <line num="76" type="stmt" count="0" />
+          <line num="78" type="stmt" count="0" />
+          <line num="79" type="stmt" count="0" />
+          <line num="80" type="stmt" count="0" />
+          <metrics loc="81" ncloc="73" classes="1" methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="44" coveredstatements="0" elements="46" coveredelements="0" />
+        </file>
+      </package>
+    </metrics>
+  </project>
+</coverage>


### PR DESCRIPTION
This demonstrates a use case a customer ran into which is preventing them from running coverage using clover -- apparently a wrapping metrics tags in clover breaks our ability to read coverage data.

@efueger opening here for visibility. 