### PR TITLE
Remove cobertura.ser from Cobertura searchPaths

### DIFF
--- a/formatters/cobertura/cobertura.go
+++ b/formatters/cobertura/cobertura.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var searchPaths = []string{"cobertura.xml", "cobertura.ser"}
+var searchPaths = []string{"cobertura.xml"}
 
 type Formatter struct {
 	Path string


### PR DESCRIPTION
Our current Cobertura parser supports XML format only. 


Related to https://github.com/codeclimate/test-reporter/issues/362