### PR TITLE
Add support for llvm.coverage.json.export format

### DIFF
--- a/cmd/format-coverage.go
+++ b/cmd/format-coverage.go
@@ -16,6 +16,7 @@ import (
 	"github.com/codeclimate/test-reporter/formatters/gocov"
 	"github.com/codeclimate/test-reporter/formatters/jacoco"
 	"github.com/codeclimate/test-reporter/formatters/lcov"
+	"github.com/codeclimate/test-reporter/formatters/lcovjson"
 	"github.com/codeclimate/test-reporter/formatters/simplecov"
 	"github.com/codeclimate/test-reporter/formatters/xccov"
 	"github.com/gobuffalo/envy"
@@ -36,7 +37,7 @@ type CoverageFormatter struct {
 var formatOptions = CoverageFormatter{}
 
 // a prioritized list of the formatters to use
-var formatterList = []string{"clover", "cobertura", "coverage.py", "excoveralls", "gcov", "gocov", "jacoco", "lcov", "simplecov", "xccov"}
+var formatterList = []string{"clover", "cobertura", "coverage.py", "excoveralls", "gcov", "gocov", "jacoco", "lcov", "lcov-json", "simplecov", "xccov"}
 
 // a map of the formatters to use
 var formatterMap = map[string]formatters.Formatter{
@@ -48,6 +49,7 @@ var formatterMap = map[string]formatters.Formatter{
 	"gocov":       &gocov.Formatter{},
 	"jacoco":      &jacoco.Formatter{},
 	"lcov":        &lcov.Formatter{},
+	"lcov-json":   &lcovjson.Formatter{},
 	"simplecov":   &simplecov.Formatter{},
 	"xccov":       &xccov.Formatter{},
 }

--- a/formatters/lcovjson/json_input.go
+++ b/formatters/lcovjson/json_input.go
@@ -1,0 +1,158 @@
+package lcovjson
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type segment struct {
+	Line int
+	Column int
+	Count int
+	HasCount bool
+	IsRegionEntry bool
+}
+
+func (segment *segment) UnmarshalJSON(data []byte) error {
+	var array []interface{}
+	if err := json.Unmarshal(data, &array); err != nil {
+		return err
+	}
+
+	if n, ok := array[0].(float64); ok {
+		segment.Line = int(n)
+	} else {
+		return errors.New("invalid Line")
+	}
+
+	if n, ok := array[1].(float64); ok {
+		segment.Column = int(n)
+	} else {
+		return errors.New("invalid Column")
+	}
+
+	if n, ok := array[2].(float64); ok {
+		segment.Count = int(n)
+	} else {
+		return errors.New("invalid Count")
+	}
+
+	if b, ok := array[3].(bool); ok {
+		segment.HasCount = b
+	} else {
+		return errors.New("invalid HasCount")
+	}
+
+	if b, ok := array[4].(bool); ok {
+		segment.IsRegionEntry = b
+	} else {
+		return errors.New("invalid IsRegionEntry")
+	}
+
+	return nil
+}
+
+type coverage struct {
+	Count int `json:"count"`
+	Covered int `json:"covered"`
+	Percent float64 `json:"percent"`
+}
+
+type summary struct {
+	Functions coverage `json:"functions"`
+	Instantiations coverage `json:"instantiations"`
+	Lines coverage `json:"lines"`
+	Regions coverage `json:"regions"`
+}
+
+type sourceFile struct {
+	Filename string `json:"filename"`
+	Segments []segment `json:"segments"`
+	Summary summary `json:"summary"`
+}
+
+type region struct {
+	LineStart int
+	ColumnStart int
+	LineEnd int
+	ColumnEnd int
+	ExecutionCount int
+	FileID int
+	ExpandedFileID int
+	Kind int
+}
+
+func (region *region) UnmarshalJSON(data []byte) error {
+	var array []interface{}
+	if err := json.Unmarshal(data, &array); err != nil {
+		return err
+	}
+
+	if n, ok := array[0].(float64); ok {
+		region.LineStart = int(n)
+	} else {
+		return errors.New("invalid LineStart")
+	}
+
+	if n, ok := array[1].(float64); ok {
+		region.ColumnStart = int(n)
+	} else {
+		return errors.New("invalid ColumnStart")
+	}
+
+	if n, ok := array[2].(float64); ok {
+		region.LineEnd = int(n)
+	} else {
+		return errors.New("invalid LineEnd")
+	}
+
+	if n, ok := array[3].(float64); ok {
+		region.ColumnEnd = int(n)
+	} else {
+		return errors.New("invalid ColumnEnd")
+	}
+
+	if n, ok := array[4].(float64); ok {
+		region.ExecutionCount = int(n)
+	} else {
+		return errors.New("invalid ExecutionCount")
+	}
+
+	if n, ok := array[5].(float64); ok {
+		region.FileID = int(n)
+	} else {
+		return errors.New("invalid FileID")
+	}
+
+	if n, ok := array[6].(float64); ok {
+		region.ExpandedFileID = int(n)
+	} else {
+		return errors.New("invalid ExpandedFileID")
+	}
+
+	if n, ok := array[7].(float64); ok {
+		region.Kind = int(n)
+	} else {
+		return errors.New("invalid Kind")
+	}
+
+	return nil
+}
+
+type function struct {
+	Count int `json:"count"`
+	Filenames []string `json:"filenames"`
+	Name string `json:"name"`
+	Regions []region `json:"regions"`
+}
+
+type lcovJsonFile struct {
+	Data []struct {
+		Files []sourceFile `json:"files"`
+		Functions []function `json:"functions"`
+		Totals summary `json:"totals"`
+	} `json:"data"`
+
+	Type string `json:"type"`
+	Version string `json:"version"`
+}

--- a/formatters/lcovjson/lcovjson.go
+++ b/formatters/lcovjson/lcovjson.go
@@ -1,0 +1,109 @@
+package lcovjson
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codeclimate/test-reporter/env"
+	"github.com/codeclimate/test-reporter/formatters"
+	"github.com/pkg/errors"
+)
+
+var searchPaths = []string{"coverage.json"}
+
+type Formatter struct {
+	Path string
+}
+
+func (f *Formatter) Search(paths ...string) (string, error) {
+	paths = append(paths, searchPaths...)
+	for _, p := range paths {
+		logrus.Debugf("checking search path %s for lcov-json formatter", p)
+		if _, err := os.Stat(p); err == nil {
+			f.Path = p
+			return p, nil
+		}
+	}
+
+	return "", errors.WithStack(errors.Errorf("could not find any files in search paths for lcov-json. search paths were: %s", strings.Join(paths, ", ")))
+}
+
+func (r Formatter) Format() (formatters.Report, error) {
+	report, err := formatters.NewReport()
+	if err != nil {
+		return report, err
+	}
+
+	inputLcovJsonFile, err := os.Open(r.Path)
+	if err != nil {
+		return report, errors.WithStack(errors.Errorf("could not open coverage file %s", r.Path))
+	}
+
+	covFile := &lcovJsonFile{}
+	err = json.NewDecoder(inputLcovJsonFile).Decode(&covFile)
+	if err != nil {
+		return report, errors.WithStack(err)
+	}
+
+	gitHead, _ := env.GetHead()
+	for _, target := range covFile.Data {
+		report.CoveredPercent = target.Totals.Lines.Percent
+		regionsByFilename := make(map[string][]region)
+
+		for _, function := range target.Functions {
+			for _, filename := range function.Filenames {
+				// Ignore dependencies.
+				if strings.Contains(filename, ".build/checkouts") {
+					logrus.Warnf("Ignored dependency file at path \"%s\".", filename)
+					continue
+				}
+
+				regionsByFilename[filename] = append(regionsByFilename[filename], function.Regions...)
+			}
+		}
+
+		for filename, regions := range regionsByFilename {
+			sourceFile, err := formatters.NewSourceFile(filename, gitHead)
+			if err != nil {
+				logrus.Warnf("Couldn't find file at path \"%s\" from %s coverage data. Ignore if the path doesn't correspond to an existent file in your repo.", filename, r.Path)
+				continue
+			}
+
+			coverage := make(map[int]formatters.NullInt)
+			lastLine := 1
+
+			for _, region := range regions {
+				for line := region.LineStart; line <= region.LineEnd; line++ {
+					coverage[line] = formatters.NewNullInt(1)
+
+					if region.ExecutionCount == 0 {
+						coverage[line] = formatters.NewNullInt(0)
+					}
+
+					if line > lastLine {
+						lastLine = line
+					}
+				}
+			}
+
+			for line := 0; line <= lastLine; line++ {
+				executionCount, isPresent := coverage[line]
+
+				if isPresent {
+					sourceFile.Coverage = append(sourceFile.Coverage, executionCount)
+				} else {
+					sourceFile.Coverage = append(sourceFile.Coverage, formatters.NullInt{})
+				}
+			}
+
+			err = report.AddSourceFile(sourceFile)
+			if err != nil {
+				return report, errors.WithStack(err)
+			}
+		}
+	}
+
+	return report, nil
+}

--- a/formatters/lcovjson/lcovjson.go
+++ b/formatters/lcovjson/lcovjson.go
@@ -11,14 +11,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-var searchPaths = []string{"coverage.json"}
-
 type Formatter struct {
 	Path string
 }
 
 func (f *Formatter) Search(paths ...string) (string, error) {
-	paths = append(paths, searchPaths...)
+	paths = append(paths)
 	for _, p := range paths {
 		logrus.Debugf("checking search path %s for lcov-json formatter", p)
 		if _, err := os.Stat(p); err == nil {

--- a/formatters/lcovjson/lcovjson.go
+++ b/formatters/lcovjson/lcovjson.go
@@ -52,12 +52,6 @@ func (r Formatter) Format() (formatters.Report, error) {
 
 		for _, function := range target.Functions {
 			for _, filename := range function.Filenames {
-				// Ignore dependencies.
-				if strings.Contains(filename, ".build/checkouts") {
-					logrus.Warnf("Ignored dependency file at path \"%s\".", filename)
-					continue
-				}
-
 				regionsByFilename[filename] = append(regionsByFilename[filename], function.Regions...)
 			}
 		}

--- a/formatters/lcovjson/lcovjson_example.json
+++ b/formatters/lcovjson/lcovjson_example.json
@@ -1,0 +1,456 @@
+{
+  "data": [
+    {
+      "files": [
+        {
+          "expansions": [],
+          "filename": "/Users/paulo/Development/GitHub/paulofaria/Codecov/Sources/Codecov/User.swift",
+          "segments": [
+            [
+              12,
+              7,
+              1,
+              true,
+              true
+            ],
+            [
+              17,
+              6,
+              0,
+              false,
+              false
+            ],
+            [
+              19,
+              26,
+              0,
+              true,
+              true
+            ],
+            [
+              21,
+              6,
+              0,
+              false,
+              false
+            ]
+          ],
+          "summary": {
+            "functions": {
+              "count": 2,
+              "covered": 1,
+              "percent": 50
+            },
+            "instantiations": {
+              "count": 2,
+              "covered": 1,
+              "percent": 50
+            },
+            "lines": {
+              "count": 9,
+              "covered": 6,
+              "percent": 66.666666666666657
+            },
+            "regions": {
+              "count": 2,
+              "covered": 1,
+              "notcovered": 1,
+              "percent": 50
+            }
+          }
+        },
+        {
+          "expansions": [],
+          "filename": "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift",
+          "segments": [
+            [
+              5,
+              24,
+              1,
+              true,
+              true
+            ],
+            [
+              18,
+              24,
+              1,
+              true,
+              true
+            ],
+            [
+              18,
+              37,
+              1,
+              true,
+              false
+            ],
+            [
+              18,
+              39,
+              1,
+              true,
+              true
+            ],
+            [
+              18,
+              47,
+              1,
+              true,
+              false
+            ],
+            [
+              19,
+              24,
+              1,
+              true,
+              true
+            ],
+            [
+              19,
+              37,
+              1,
+              true,
+              false
+            ],
+            [
+              19,
+              39,
+              1,
+              true,
+              true
+            ],
+            [
+              19,
+              47,
+              1,
+              true,
+              false
+            ],
+            [
+              20,
+              24,
+              1,
+              true,
+              true
+            ],
+            [
+              20,
+              38,
+              1,
+              true,
+              false
+            ],
+            [
+              20,
+              40,
+              1,
+              true,
+              true
+            ],
+            [
+              20,
+              49,
+              1,
+              true,
+              false
+            ],
+            [
+              21,
+              24,
+              1,
+              true,
+              true
+            ],
+            [
+              21,
+              37,
+              1,
+              true,
+              false
+            ],
+            [
+              21,
+              39,
+              1,
+              true,
+              true
+            ],
+            [
+              21,
+              47,
+              1,
+              true,
+              false
+            ],
+            [
+              22,
+              6,
+              0,
+              false,
+              false
+            ]
+          ],
+          "summary": {
+            "functions": {
+              "count": 9,
+              "covered": 9,
+              "percent": 100
+            },
+            "instantiations": {
+              "count": 9,
+              "covered": 9,
+              "percent": 100
+            },
+            "lines": {
+              "count": 26,
+              "covered": 26,
+              "percent": 100
+            },
+            "regions": {
+              "count": 9,
+              "covered": 9,
+              "notcovered": 0,
+              "percent": 100
+            }
+          }
+        }
+      ],
+      "functions": [
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Sources/Codecov/User.swift"
+          ],
+          "name": "$s7Codecov4UserV8username8password9firstName04lastF0ACSS_S3StcfC",
+          "regions": [
+            [
+              12,
+              7,
+              17,
+              6,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 0,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Sources/Codecov/User.swift"
+          ],
+          "name": "$s7Codecov4UserV8fullNameSSvg",
+          "regions": [
+            [
+              19,
+              26,
+              21,
+              6,
+              0,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyF",
+          "regions": [
+            [
+              5,
+              24,
+              22,
+              6,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu_",
+          "regions": [
+            [
+              18,
+              24,
+              18,
+              37,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu0_",
+          "regions": [
+            [
+              18,
+              39,
+              18,
+              47,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu1_",
+          "regions": [
+            [
+              19,
+              24,
+              19,
+              37,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu2_",
+          "regions": [
+            [
+              19,
+              39,
+              19,
+              47,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu3_",
+          "regions": [
+            [
+              20,
+              24,
+              20,
+              38,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu4_",
+          "regions": [
+            [
+              20,
+              40,
+              20,
+              49,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu5_",
+          "regions": [
+            [
+              21,
+              24,
+              21,
+              37,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        {
+          "count": 1,
+          "filenames": [
+            "/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"
+          ],
+          "name": "$s12CodecovTestsAAC11testExampleyyFSSyKXEfu6_",
+          "regions": [
+            [
+              21,
+              39,
+              21,
+              47,
+              1,
+              0,
+              0,
+              0
+            ]
+          ]
+        }
+      ],
+      "totals": {
+        "functions": {
+          "count": 11,
+          "covered": 10,
+          "percent": 90.909090909090907
+        },
+        "instantiations": {
+          "count": 11,
+          "covered": 10,
+          "percent": 90.909090909090907
+        },
+        "lines": {
+          "count": 35,
+          "covered": 32,
+          "percent": 91.428571428571431
+        },
+        "regions": {
+          "count": 11,
+          "covered": 10,
+          "notcovered": 1,
+          "percent": 90.909090909090907
+        }
+      }
+    }
+  ],
+  "type": "llvm.coverage.json.export",
+  "version": "2.0.0"
+}

--- a/formatters/lcovjson/lcovjson_test.go
+++ b/formatters/lcovjson/lcovjson_test.go
@@ -1,0 +1,43 @@
+package lcovjson
+
+import (
+	"testing"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+
+	"github.com/codeclimate/test-reporter/env"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Format(t *testing.T) {
+	gb := env.GitBlob
+	defer func() { env.GitBlob = gb }()
+	env.GitBlob = func(s string, c *object.Commit) (string, error) {
+		return s, nil
+	}
+
+	r := require.New(t)
+
+	rb := Formatter{
+		Path: "./lcovjson_example.json",
+	}
+	rep, err := rb.Format()
+	r.NoError(err)
+
+	r.InDelta(rep.CoveredPercent, 88.8, 1)
+
+	sf := rep.SourceFiles["/Users/paulo/Development/GitHub/paulofaria/Codecov/Sources/Codecov/User.swift"]
+
+	r.InDelta(sf.CoveredPercent, 66.66, 1)
+	sfLc := sf.LineCounts
+	r.Equal(sfLc.Covered, 6)
+	r.Equal(sfLc.Missed, 3)
+	r.Equal(sfLc.Total, 9)
+
+	sf = rep.SourceFiles["/Users/paulo/Development/GitHub/paulofaria/Codecov/Tests/CodecovTests/CodecovTests.swift"]
+	r.InDelta(sf.CoveredPercent, 100, 1)
+	sfLc = sf.LineCounts
+	r.Equal(sfLc.Covered, 18)
+	r.Equal(sfLc.Missed, 0)
+	r.Equal(sfLc.Total, 18)
+}


### PR DESCRIPTION
This PR adds support for the llvm.coverage.json.export format. This is the format generated by the Swift Package Manager. The commands below allow you to generate the coverage file:

```console
mkdir TestCoverage
cd TestCoverage
swift package init
swift test --enable-code-coverage  
swift test --show-codecov-path
```

The last command shows the path of the generated coverage file. I added a new formatter called `lcov-json` which can be used like so:

```console
test-reporter format-coverage $(swift test --show-codecov-path) -t lcov-json    
```
