### PR TITLE
Specify circleci/golang image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test_linux:
     docker:
-      - image: circleci/golang
+      - image: circleci/golang:1.15
     working_directory: /go/src/github.com/codeclimate/test-reporter
     setup_remote_docker:
       docker_layer_caching: true


### PR DESCRIPTION
Using `latest` versions of images is generally not recommended. Our current [linux build is failing](https://github.com/codeclimate/test-reporter/pull/461#discussion_r579651754) due to a recent change in `circleci/golang`. This PR specifies the previous working image.