### PR TITLE
Sepcify golang version for mac build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
   release_linux:
     docker:
-      - image: circleci/golang
+      - image: circleci/golang:1.15
     working_directory: /go/src/github.com/codeclimate/test-reporter
     setup_remote_docker:
       docker_layer_caching: true
@@ -27,7 +27,12 @@ jobs:
       xcode: "11.3.0"
     steps:
       - checkout
-      - run: brew install golang
+      - run:
+          name: Install go
+          command: |
+            curl -O https://dl.google.com/go/go1.15.darwin-amd64.tar.gz
+            tar -xzf go1.15.darwin-amd64.tar.gz
+            echo 'export PATH=$PATH:$PWD/go/bin' >> "$BASH_ENV"
       - run:
           name: Setup gopath
           command: |
@@ -48,7 +53,12 @@ jobs:
     steps:
       - checkout
       - run: pip install awscli
-      - run: brew install golang
+      - run:
+          name: Install go
+          command: |
+            curl -O https://dl.google.com/go/go1.15.darwin-amd64.tar.gz
+            tar -xzf go1.15.darwin-amd64.tar.gz
+            echo 'export PATH=$PATH:$PWD/go/bin' >> "$BASH_ENV"
       - run:
           name: Setup gopath
           command: |


### PR DESCRIPTION
The [current build is failing ](https://github.com/codeclimate/test-reporter/pull/461#issuecomment-786321756)due to mac os environment using `go 1.16` instead of `1.15` which seems to have broken our ci for both linux and macos. Installing golang 1.15 using brew wasn't possible so I installed it manually. 