### PR TITLE
Fix gocov formatting issue #479

### DIFF
--- a/formatters/gocov/gocov.go
+++ b/formatters/gocov/gocov.go
@@ -60,7 +60,6 @@ func (r Formatter) Format() (formatters.Report, error) {
 		if err != nil {
 			return rep, errors.WithStack(err)
 		}
-		num := 0
 		blocks := []cover.ProfileBlock{}
 		for _, b := range p.Blocks {
 			lstIdx := len(blocks) - 1
@@ -70,14 +69,15 @@ func (r Formatter) Format() (formatters.Report, error) {
 			}
 			blocks[lstIdx].Count += b.Count
 		}
+		lineNum := 1
 		for _, b := range blocks {
-			for num < b.StartLine {
+			for lineNum < b.StartLine {
 				sf.Coverage = append(sf.Coverage, formatters.NullInt{})
-				num++
+				lineNum++
 			}
-			for i := 0; i < b.NumStmt; i++ {
+			for lineNum <= b.EndLine {
 				sf.Coverage = append(sf.Coverage, formatters.NewNullInt(b.Count))
-				num++
+				lineNum++
 			}
 		}
 		err = rep.AddSourceFile(sf)

--- a/formatters/gocov/gocov_test.go
+++ b/formatters/gocov/gocov_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func Test_Parse(t *testing.T) {
-
 	t.Run("should parse report from single package", func(t *testing.T) {
 		gb := env.GitBlob
 		defer func() { env.GitBlob = gb }()
@@ -27,17 +26,17 @@ func Test_Parse(t *testing.T) {
 		r.Len(rep.SourceFiles, 4)
 
 		sf := rep.SourceFiles["github.com/codeclimate/test-reporter/formatters/source_file.go"]
-		r.InDelta(77.4, sf.CoveredPercent, 1)
-		r.Len(sf.Coverage, 116)
+		r.InDelta(75.8, sf.CoveredPercent, 1)
+		r.Len(sf.Coverage, 115)
 		r.False(sf.Coverage[5].Valid)
 		r.True(sf.Coverage[54].Valid)
-		r.Equal(0, sf.Coverage[53].Int)
+		r.Equal(0, sf.Coverage[52].Int)
 		r.Equal(1, sf.Coverage[55].Int)
 	})
 
 	//
 	// Test parsing report that was generated using `-coverpkg` flag.
-	// 
+	//
 	// go test \
 	// -coverpkg="github.com/codeclimate/test-reporter/formatters/gocov/example/foo,github.com/codeclimate/test-reporter/formatters/gocov/example/bar" \
 	// -coverprofile=example_foobar.out \
@@ -61,9 +60,8 @@ func Test_Parse(t *testing.T) {
 		sfFoo := rep.SourceFiles["example/foo/foo.go"]
 		sfBar := rep.SourceFiles["example/bar/bar.go"]
 
-		r.EqualValues(87.5, rep.CoveredPercent)
+		r.EqualValues(85, rep.CoveredPercent)
 		r.EqualValues(100, sfFoo.CoveredPercent)
 		r.InDelta(66.66, sfBar.CoveredPercent, 0.01)
 	})
-
 }


### PR DESCRIPTION
This PR fixes issue https://github.com/codeclimate/test-reporter/issues/479

The formatter used to assume that the number of statements always equals
the number of lines in a block. This is not true when there are blank
lines for example. This change colours by line number rather than by
statement.