### PR TITLE
Make simplecov json formatter more flexible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ linux_image: &linux_image
 
 macos_image: &macos_image
   macos:
-    xcode: "11.3.0"
+    xcode: "11.4.0"
 
 setup_macos_env: &setup_macos_env
 

--- a/formatters/simplecov/json_formatter.go
+++ b/formatters/simplecov/json_formatter.go
@@ -61,7 +61,6 @@ func jsonFormat(r Formatter, rep formatters.Report) (formatters.Report, error) {
 
 	var m simplecovJsonFormatterReport
 	decoder := json.NewDecoder(jf)
-	decoder.DisallowUnknownFields()
 
 	err = decoder.Decode(&m)
 

--- a/formatters/simplecov/simplecov-with-groups.json
+++ b/formatters/simplecov/simplecov-with-groups.json
@@ -1,0 +1,158 @@
+{
+  "meta": {
+    "simplecov_version": "0.19.0"
+  },
+  "coverage": {
+    "development/mygem/lib/mygem/errors.rb": {
+      "lines": [
+        1,
+        null,
+        1,
+        1,
+        0,
+        null,
+        null,
+        null,
+        1,
+        null,
+        null,
+        null,
+        1,
+        null,
+        null,
+        null,
+        1,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    "development/mygem/lib/mygem/definition_manager.rb": {
+      "lines": [
+        1,
+        1,
+        1,
+        null,
+        1,
+        null,
+        1,
+        1,
+        null,
+        null,
+        1,
+        8,
+        null,
+        null,
+        1,
+        19,
+        null,
+        null,
+        1,
+        null,
+        1,
+        8,
+        null,
+        null,
+        1,
+        11,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    "development/mygem/lib/mygem/interface.rb": {
+      "lines": [
+        1,
+        null,
+        1,
+        1,
+        null,
+        1,
+        8,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    "development/mygem/lib/mygem/implements.rb": {
+      "lines": [
+        1,
+        null,
+        1,
+        9,
+        null,
+        null,
+        null
+      ]
+    },
+    "development/mygem/lib/mygem/implementation_manager.rb": {
+      "lines": [
+        1,
+        1,
+        1,
+        null,
+        1,
+        null,
+        1,
+        1,
+        null,
+        null,
+        1,
+        9,
+        null,
+        null,
+        1,
+        82,
+        null,
+        null,
+        1,
+        null,
+        1,
+        9,
+        null,
+        null,
+        1,
+        73,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    "development/mygem/lib/mygem/wrap.rb": {
+      "lines": [
+        1,
+        null,
+        1,
+        17,
+        20,
+        16,
+        16,
+        12,
+        null,
+        null
+      ]
+    },
+    "development/mygem/lib/mygem/type_check.rb": {
+      "lines": [
+        1,
+        null,
+        1,
+        7,
+        7,
+        7,
+        null,
+        null,
+        null
+      ]
+    }
+  },
+  "groups": {}
+}

--- a/formatters/simplecov/simplecov_test.go
+++ b/formatters/simplecov/simplecov_test.go
@@ -248,3 +248,30 @@ func Test_Format_Merged(t *testing.T) {
 	assert.Equal(lc.Missed, 2)
 	assert.Equal(lc.Total, 8)
 }
+
+func Test_ParseWithGroups(t *testing.T) {
+	ogb := env.GitBlob
+	defer func() {
+		env.GitBlob = ogb
+	}()
+	env.GitBlob = func(s string, c *object.Commit) (string, error) {
+		return s, nil
+	}
+
+	assert := require.New(t)
+
+	formatter := Formatter{
+		Path: "./simplecov-with-groups.json",
+	}
+	rep, err := formatter.Format()
+	assert.NoError(err)
+
+	assert.Len(rep.SourceFiles, 7)
+
+	cf := rep.SourceFiles["development/mygem/lib/mygem/wrap.rb"]
+	assert.Len(cf.Coverage, 10)
+	for i, x := range []interface{}{1, nil, 1, 17, 20, 16, 16, 12, nil, nil} {
+		l := cf.Coverage[i]
+		assert.Equal(x, l.Interface())
+	}
+}


### PR DESCRIPTION
`simplecov_json_formatter`'s json report now contains an extra key, named `groups`. This was included on https://github.com/codeclimate-community/simplecov_json_formatter/pull/2 . The current approach for decoding the JSON report into a predefined struct is too rigid due to the use of `DisallowUnkownFields()`.

> DisallowUnknownFields causes the Decoder to return an error when the destination is a struct and the input contains object keys which do not match any non-ignored, exported fields in the destination.
> [Godoc](https://pkg.go.dev/encoding/json#Decoder.DisallowUnknownFields)

That explains why the test report will fail to decode the new `simplecov_json_formatter` report, since it has a new key `groups` which is not declared on the struct.

This `DisallowUknownFields()` was use as a strategy to detect when the given `simplecov` report is on legacy format (simplecov < 0.18). I'm changing the strategy to extract the `simplecov` version from the test report and make a decision about with simplecov formatter to use based on that.


