### PR TITLE
Fix CI xcode_install_go script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ linux_image: &linux_image
 
 macos_image: &macos_image
   macos:
-    xcode: "11.4.0"
+    xcode: "11.7.0"
 
 setup_macos_env: &setup_macos_env
 

--- a/.circleci/xcode_install_go
+++ b/.circleci/xcode_install_go
@@ -9,15 +9,16 @@ set -o errexit
 set -o pipefail
 
 PROJECT_RELATIVE_PATH=src/github.com/codeclimate/test-reporter
-            
-# Install go
+
+# Install goSDK
+mkdir ~/gosdk && cd "$_"
+echo 'export PATH=$PATH:$HOME/gosdk/go/bin' >> "$BASH_ENV"
+echo 'export GOROOT=$HOME/gosdk/go' >> "$BASH_ENV"
 curl -O https://dl.google.com/go/go1.15.darwin-amd64.tar.gz
 tar -xzf go1.15.darwin-amd64.tar.gz
-echo 'export PATH=$PATH:$PWD/go/bin' >> "$BASH_ENV"
 
-# Set go path
-mkdir -p ~/gopath/${PROJECT_RELATIVE_PATH}
-echo 'export GOPATH=$HOME/gopath' >> "$BASH_ENV"
+# Set go path - workspace root
+mkdir -p ~/projects/go/${PROJECT_RELATIVE_PATH} && cd "$_"
+echo 'export GOPATH=$HOME/projects/go' >> "$BASH_ENV"
 . "$BASH_ENV"
-cd $GOPATH/${PROJECT_RELATIVE_PATH}
 cp -r ~/project/ $GOPATH/${PROJECT_RELATIVE_PATH}


### PR DESCRIPTION
Triggered [by this comment,](https://github.com/codeclimate/test-reporter/pull/497#pullrequestreview-1061189720) I realized CircleCI job `test_macos` wasn't running properly. While it was throwing a success message, it wasn't running the tests.

See latest master output for this job: https://app.circleci.com/pipelines/github/codeclimate/test-reporter/122/workflows/b88128a1-eaa3-4114-aff8-b0006868438d/jobs/1171/parallel-runs/0/steps/0-103 and compare it with the current fix: https://app.circleci.com/pipelines/github/codeclimate/test-reporter/142/workflows/4b039486-57fd-4850-9011-23285cfe264d/jobs/1219/parallel-runs/0/steps/0-103

Before:
<img width="2037" alt="image" src="https://user-images.githubusercontent.com/52419977/182915124-75fc51eb-ffc0-4a27-82c7-5ca68cbcb995.png">

After:
<img width="2036" alt="image" src="https://user-images.githubusercontent.com/52419977/182915182-f2a0548f-968d-4ef8-85d8-b725aa7eb39f.png">


