### PR TITLE
Fix release_head_macos and release_head_linux jobs after upgrading xcode base image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     <<: *linux_image
     steps:
       - checkout
-      - run: sudo apt-get install awscli
+      - run: sudo apt-get update && sudo apt-get install awscli
       - run: make build-linux-all VERSION=head
       - run: make publish-head
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     <<: *macos_image
     steps:
       - checkout
-      - run: pip install awscli
+      - run: pip3 install awscli
       - run:
           command: sh .circleci/xcode_install_go
       - run:


### PR DESCRIPTION
#### release_head_macos
- After upgrading the XCode version on our `macos_image` for CircleCI jobs on #498 , the pip version was also upgraded, so we should use `pip3` instead of `pip`. 

Failed job: https://app.circleci.com/pipelines/github/codeclimate/test-reporter/144/workflows/88253465-f0e4-4fdd-8232-4d51b61d03a4/jobs/1225
CircleCi image manifest: https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html

#### release_head_linux
- Linux repository was pointing to a non-existing package, causing the job to fail. Running `apt-get update` fixes the issue.

```
http://deb.debian.org/debian/pool/main/p/pillow/python3-pil_5.4.1-2+deb10u2_amd64.deb # Before
http://deb.debian.org/debian/pool/main/p/pillow/python3-pil_5.4.1-2+deb10u3_amd64.deb  # After
```
Reference: http://deb.debian.org/debian/pool/main/p/pillow/

Failed  job: https://app.circleci.com/pipelines/github/codeclimate/test-reporter/144/workflows/88253465-f0e4-4fdd-8232-4d51b61d03a4/jobs/1226

