### PR TITLE
Make ARM64 version available for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ build-docker:
 build-docker-linux:
 	$(MAKE) build-docker GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 
+build-docker-linux-arm64:
+	$(MAKE) build-docker GOOS=linux GOARCH=arm64 CGO_ENABLED=0
+
 build-docker-linux-cgo:
 	$(MAKE) build-docker GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
 		BUILD_TAGS="netcgo" BINARY_SUFFIX=-$(VERSION)-netcgo-linux-amd64
@@ -144,6 +147,9 @@ publish-version:
 gen-linux-checksum:
 	$(call gen_signed_checksum,linux-amd64)
 
+gen-linux-arm64-checksum:
+	$(call gen_signed_checksum,linux-arm64)
+
 gen-linux-cgo-checksum:
 	$(call gen_signed_checksum,netcgo-linux-amd64)
 
@@ -161,15 +167,19 @@ tag:
 # Must be run in a OS X machine. OS X binary is build natively.
 manual-release:
 	$(MAKE) build-docker-linux
+	$(MAKE) build-docker-linux-arm64
 	$(MAKE) build-docker-linux-cgo
 	$(MAKE) build-darwin
 	$(MAKE) gen-linux-checksum
+	$(MAKE) gen-linux-arm64-checksum
 	$(MAKE) gen-linux-cgo-checksum
 	$(MAKE) gen-darwin-checksum
 	$(MAKE) build-docker-linux VERSION=latest
+	$(MAKE) build-docker-linux-arm64 VERSION=latest
 	$(MAKE) build-docker-linux-cgo VERSION=latest
 	$(MAKE) build-darwin VERSION=latest
 	$(MAKE) gen-linux-checksum VERSION=latest
+	$(MAKE) gen-linux-arm64-checksum VERSION=latest
 	$(MAKE) gen-linux-cgo-checksum VERSION=latest
 	$(MAKE) gen-darwin-checksum VERSION=latest
 	$(MAKE) publish-version

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,13 @@ build-linux:
 	  BINARY_SUFFIX=-$(VERSION)-linux-amd64 \
 	  CGO_ENABLED=0
 
+build-linux-arm64:
+	$(MAKE) build \
+		PREFIX=artifacts/ \
+		BINARY_SUFFIX=-$(VERSION)-linux-arm64 \
+		CGO_ENABLED=0 \
+		GOARCH=arm64
+
 build-linux-cgo:
 	$(MAKE) build \
 	  PREFIX=artifacts/ \
@@ -66,6 +73,7 @@ build-linux-cgo:
 
 build-linux-all:
 	$(MAKE) build-linux
+	$(MAKE) build-linux-arm64
 	$(MAKE) build-linux-cgo
 
 build-darwin:


### PR DESCRIPTION
Updated Makefile so the ARM64 version of the test-reporter is available to be built.

```
➜  test-reporter git:(QUA-795/ARM-binary-release) file --brief artifacts/bin/test-reporter-0.10.3-linux-arm64
ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=rp0JmTgqwUwNjGy_zlc0/jm6vqQgU7nHL3Gu1471w/laH10Nt_Y0gKwCvZ6rFa/Emf5LCySp9699oRMiyME, not stripped
```

So far, it has been tested by successfully uploading a test coverage from an Ubuntu arm64 image using this new test-coverage binary.

```
...
Test report uploaded successfully to Code Climate
root@6a4529efb71e:/test-project# uname -m
aarch64
root@6a4529efb71e:/test-project# /artifacts/test-reporter-0.10.3-linux-arm64 env
GIT_BRANCH=main
GIT_COMMIT_SHA=d860ac535656884cc17b5fb1021c9864bc44277f
GIT_COMMITTED_AT=1650896777
```

I also updated the Makefile so the release of this binary is included on new releases. For this, I run the new `build-linux-arm64` command inside a `circleci/golang:1.15` container to be sure everything is ok -> The binary was built successfully. 
```
$ readelf -h artifacts/bin/test-reporter-0.10.4-linux-arm64 | grep 'Class\|File\|Machine'
  Class:                             ELF64
  Machine:                           AArch64
```


⚠️  Is it worth creating a CI step for running the tests on a linux arm64 image? 


Generated ARM64 binary ⬇️ 
[test-reporter-0.10.4-linux-arm64.zip](https://github.com/codeclimate/test-reporter/files/9870570/test-reporter-0.10.4-linux-arm64.zip)
