### PR TITLE
Update README with linux ARM64 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The test reporter is distributed as a pre-built binary named cc-test-reporter. Y
 - [codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64](https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64)
 - [codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-amd64](https://codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-amd64)
 
+### Linux ARM64
+- [codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-arm64](https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-arm64)
+- [codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-amd64](https://codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-arm64)
 
 ### Linux netcgo (recommended if you're using a VPN)
 - [codeclimate.com/downloads/test-reporter/test-reporter-latest-netcgo-linux-amd64](https://codeclimate.com/downloads/test-reporter/test-reporter-latest-netcgo-linux-amd64)


### PR DESCRIPTION
Now that ARM64 binaries have been uploaded, update the README so they are visible to users.