### PR TITLE
Fix README ARM link version typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The test reporter is distributed as a pre-built binary named cc-test-reporter. Y
 
 ### Linux ARM64
 - [codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-arm64](https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-arm64)
-- [codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-amd64](https://codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-arm64)
+- [codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-arm64](https://codeclimate.com/downloads/test-reporter/test-reporter-${VERSION}-linux-arm64)
 
 ### Linux netcgo (recommended if you're using a VPN)
 - [codeclimate.com/downloads/test-reporter/test-reporter-latest-netcgo-linux-amd64](https://codeclimate.com/downloads/test-reporter/test-reporter-latest-netcgo-linux-amd64)


### PR DESCRIPTION
On https://github.com/codeclimate/test-reporter/pull/503 the links for the ARM64 version were introduced, but there was a typo on the link description.