### PR TITLE
Bug/add prefix

### DIFF
--- a/formatters/source_file.go
+++ b/formatters/source_file.go
@@ -105,6 +105,7 @@ func NewSourceFile(name string, commit *object.Commit) (SourceFile, error) {
 
 	if addPrefix, err := envy.MustGet("ADD_PREFIX"); err == nil {
 		if addPrefix != "" {
+			logrus.Printf("adding prefix %s", addPrefix)
 			if strings.HasSuffix(addPrefix, string(os.PathSeparator)) {
 				sf.Name = addPrefix + sf.Name
 			} else {

--- a/formatters/source_file.go
+++ b/formatters/source_file.go
@@ -91,6 +91,17 @@ func NewSourceFile(name string, commit *object.Commit) (SourceFile, error) {
 		}
 	}
 
+	if addPrefix, err := envy.MustGet("ADD_PREFIX"); err == nil {
+		if addPrefix != "" {
+			logrus.Printf("adding prefix %s", addPrefix)
+			if strings.HasSuffix(addPrefix, string(os.PathSeparator)) {
+				name = addPrefix + name
+			} else {
+				name = addPrefix + string(os.PathSeparator) + name
+			}
+		}
+	}
+
 	sf := SourceFile{
 		Name:     name,
 		Coverage: Coverage{},
@@ -101,17 +112,6 @@ func NewSourceFile(name string, commit *object.Commit) (SourceFile, error) {
 
 	if err != nil {
 		return sf, errors.WithStack(err)
-	}
-
-	if addPrefix, err := envy.MustGet("ADD_PREFIX"); err == nil {
-		if addPrefix != "" {
-			logrus.Printf("adding prefix %s", addPrefix)
-			if strings.HasSuffix(addPrefix, string(os.PathSeparator)) {
-				sf.Name = addPrefix + sf.Name
-			} else {
-				sf.Name = addPrefix + string(os.PathSeparator) + sf.Name
-			}
-		}
 	}
 
 	return sf, nil

--- a/formatters/source_file_test.go
+++ b/formatters/source_file_test.go
@@ -97,23 +97,22 @@ func Test_SourceFile_Merge_With_Mismatch_Blob_Id(t *testing.T) {
 
 func Test_SourceFile_AddPrefix(t *testing.T) {
 	envy.Temp(func() {
-		envy.Set("ADD_PREFIX", "test-prefix")
-		envy.Set("PREFIX", ".")
+		envy.Set("ADD_PREFIX", "lcov")
 		r := require.New(t)
-		sf, err := NewSourceFile("./coverage.go", nil)
+		sf, err := NewSourceFile("example.info", nil)
 		r.NoError(err)
-		r.Equal(sf.Name, "test-prefix/coverage.go")
+		r.Equal(sf.Name, "lcov/example.info")
 	})
 }
 
 func Test_SourceFile_AddPrefixWithPathSeparator(t *testing.T) {
 	envy.Temp(func() {
-		envy.Set("ADD_PREFIX", "test-prefix/")
+		envy.Set("ADD_PREFIX", "lcov/")
 		envy.Set("PREFIX", ".")
 		r := require.New(t)
-		sf, err := NewSourceFile("./coverage.go", nil)
+		sf, err := NewSourceFile("./example.info", nil)
 		r.NoError(err)
-		r.Equal(sf.Name, "test-prefix/coverage.go")
+		r.Equal(sf.Name, "lcov/example.info")
 	})
 }
 


### PR DESCRIPTION
My use case is running the cc-test-reporter from the project root whereas my coverage files for the frontend are located in `./frontend/test-coverage/lcov.info`. I managed to get `format-coverage` to work only by first `cd frontend`. Which led me to believe the `ADD_PREFIX` flag isn't really working. At least for `lcov` files, because loading the source file is attempted before any prefix is added. And if adding a prefix is required then this will naturally fail. 🤔 Or maybe I'm missing something...

I'm reverting some changes made in this PR: https://github.com/codeclimate/test-reporter/pull/232

- Add prefix before loading source file.
- Update tests.
- Add some logging.

---

This bug is also mentioned here: https://github.com/codeclimate/test-reporter/issues/422#issuecomment-1242757968
Possibly but not necessarily related: https://github.com/codeclimate/test-reporter/issues/487