### PR TITLE
Fix examples that use simplecov

### DIFF
--- a/examples/multiple_suites.md
+++ b/examples/multiple_suites.md
@@ -54,6 +54,9 @@ jobs:
           command: |
             bundle exec rake
             ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.backend.json coverage/backend/.resultset.json
+          environment:
+            # Note that to make simplecov output in appropriate format, `CC_TEST_REPORTER_ID` environment variable should be set before testing
+            - CC_TEST_REPORTER_ID: 1acf55093f33b525eefdd9fb1e601d748e5d8b1267729176605edb4b5d82dc3d
       - persist_to_workspace:
           root: tmp
           paths:

--- a/examples/ruby_examples.md
+++ b/examples/ruby_examples.md
@@ -37,6 +37,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
+  # Note that to make simplecov output in appropriate format, `CC_TEST_REPORTER_ID` environment variable should be set before testing
   - bundle exec rake $TASKS
 
 after_script:
@@ -100,6 +101,7 @@ before_script: bundle exec rake db:create db:migrate
 # Run the test suites
 script:
   - bundle exec rubocop -DESP           # Backend linting
+  # Note that to make simplecov output in appropriate format, `CC_TEST_REPORTER_ID` environment variable should be set before testing
   - bundle exec rake                    # Backend specs
   #- npm test -- --browsers Firefox      # Frontend specs
   - npm test                            # Frontend linting & specs
@@ -204,6 +206,9 @@ jobs:
                               --out test-results/rspec/rspec.xml \
                               --format progress \
                               -- ${TESTFILES}
+          environment:
+            # Note that to make simplecov output in appropriate format, `CC_TEST_REPORTER_ID` environment variable should be set before testing
+            CC_TEST_REPORTER_ID: c3ff91e23ea0fea718bb62dae0a8a5440dc082d5d2bb508af6b33d0babac479a
       - run:
           name: Code Climate Test Coverage
           command: |


### PR DESCRIPTION
As I mentioned in https://github.com/codeclimate/test-reporter/issues/495#issuecomment-1501130249, `cc-test-reporter format-coverage --input-type=simplecov` needs the test to have run with `CC_TEST_REPORTER_ID` is set, otherwise it parses a coverage file in legacy format that crashes `cc-test-reporter`.

I would like @fede-moya to review this one, please.